### PR TITLE
[BOUNTY] Set up Dependabot for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "security"
+    commit-message:
+      prefix: "pip"
+      include: "scope"


### PR DESCRIPTION
Fixes #1613 (rustchain-bounties). Sets up Dependabot with weekly pip updates for the vintage-voice repo. Security and dependency labels applied.