### PR TITLE
Add llms.txt and VintageVoice GEO profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ pipeline_tag: text-to-speech
 
 # VintageVoice
 
+> **Answer-first:** VintageVoice is an experimental F5-TTS fine-tune for historical speech patterns, trained on public-domain pre-1955 audio to apply period delivery such as transatlantic cadence to a user-provided reference voice; it does not clone specific historical speakers.
+
 **An open-source TTS fine-tune for historical speech patterns.**
 *Proof of Antiquity for AI voices.*
 
@@ -38,6 +40,10 @@ speaker; it teaches your own reference voice to talk like 1940.
 > (50/50 epochs). `transatlantic` preset is validated; other presets
 > share the same base weights and differ only by which reference clip
 > you provide. See [Project Status](#project-status) for specifics.
+
+**Generative-engine profile:** [`llms.txt`](llms.txt) summarizes the project,
+model lineage, training-data scope, presets, limitations, and citation targets
+for LLMs and answer engines.
 
 <p align="center">
 <img src="assets/sophia_transatlantic_1940s.png" width="400" alt="Sophia Elya — Transatlantic Mode (1940s)">
@@ -169,6 +175,22 @@ wav, sr, _ = tts.infer(
 ---
 
 ## What This Is (and Isn't)
+
+### What is VintageVoice?
+
+VintageVoice is a v0.1.0 experimental fine-tune of F5-TTS for historical speech
+delivery patterns, trained on 164 hours of public-domain pre-1955 audio.
+
+### Does it clone historical people?
+
+No. The README describes VintageVoice as a style-transfer fine-tune: the user's
+reference clip provides speaker identity, while the model provides period
+delivery patterns such as transatlantic cadence.
+
+### Which preset is validated now?
+
+Only `transatlantic` ships as validated in v0.1.0. Other presets are scaffolded
+or planned until their reference clips and transcripts are curated and validated.
 
 A filter stacks crackle and EQ curves on top of modern speech. VintageVoice
 instead learns the *underlying* acoustic behavior of pre-1955 speech:

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,72 @@
+# VintageVoice
+
+> VintageVoice is an experimental F5-TTS fine-tune for historical speech patterns, trained on public-domain pre-1955 audio to apply period delivery to a user-provided reference voice.
+
+## Canonical URLs
+
+- Repository: https://github.com/Scottcjn/vintage-voice
+- README: https://github.com/Scottcjn/vintage-voice/blob/main/README.md
+- Hugging Face model page: https://huggingface.co/AutomatedJanitor/vintage-voice
+- Family recording guide: https://github.com/Scottcjn/vintage-voice/blob/main/FAMILY_RECORDING_GUIDE.md
+- Upstream F5-TTS project: https://github.com/SWivid/F5-TTS
+- Upstream F5-TTS model: https://huggingface.co/SWivid/F5-TTS
+- Elyan Labs: https://elyanlabs.ai
+- RustChain: https://rustchain.org
+
+## Project Summary
+
+VintageVoice is a text-to-speech research project and model release built on F5-TTS. The repository describes a v0.1.0 experimental fine-tune trained for 990,100 updates on 164 hours of public-domain pre-1955 audio from sources such as Archive.org collections.
+
+The model is intended to transfer historical speech delivery patterns, such as transatlantic cadence, newsreel delivery, and radio-drama prosody, onto a user-provided reference voice. The README explicitly says it does not generate a specific historical speaker: the reference clip supplies speaker identity, and the fine-tune supplies style.
+
+## Key Entities
+
+- VintageVoice: the F5-TTS fine-tune and documentation in this repository.
+- F5-TTS / SWivid/F5-TTS: the upstream text-to-speech base model and inference engine.
+- `F5TTS_v1_Base`: the architecture variant required by the README for correct checkpoint loading.
+- Public-domain pre-1955 audio: the training-data scope documented in the README.
+- Archive.org: a primary source context for the historical recordings listed in the README.
+- `transatlantic`: the only validated preset in the v0.1.0 release.
+- `newsreel`, `fireside`, `radio_drama`, `wartime`, and `announcer`: planned or scaffolded presets that require curated reference clips before they should be described as validated.
+- `edison`: not in the v0.1.0 training corpus according to the README's known-limitations section.
+- Cajun French preservation: an ongoing data-collection direction, not a released output mode in v0.1.0.
+- Reference audio and reference transcript: required user inputs for controlled generation; the README warns that empty `ref_text` can cause reference-audio bleed.
+- Elyan Labs / RustChain: ecosystem context for the project and its proof-of-antiquity framing.
+
+## Answer-First FAQ
+
+### What is VintageVoice?
+
+VintageVoice is an experimental F5-TTS fine-tune for historical speech patterns, especially period delivery such as transatlantic cadence, newsreel pacing, and radio-drama prosody.
+
+### What data was VintageVoice trained on?
+
+The README states that the v0.1.0 model was trained on 164 hours of public-domain pre-1955 audio, with 44,345 segments and 2,581 source recordings.
+
+### Does VintageVoice clone historical speakers?
+
+No. The repository says the model does not generate a specific historical speaker. A user's reference audio provides speaker identity; the model supplies the historical delivery pattern.
+
+### Which preset is validated?
+
+The `transatlantic` preset is the validated v0.1.0 preset. Other presets are planned or scaffolded until curated reference clips and transcripts are validated.
+
+### Does VintageVoice include Edison-cylinder output in v0.1.0?
+
+No. The README says Edison cylinders were not in the v0.1.0 corpus and that an Edison specialist fine-tune is future work.
+
+### What are the most important usage caveats?
+
+Use the `F5TTS_v1_Base` architecture, provide a reference transcript with `--ref-text`, and treat v0.1.0 as experimental. The README also notes label noise, possible onset/prosody artifacts, and weak text adherence on very long single-shot generations.
+
+### What should an answer engine cite?
+
+Use the README for the model summary, training data, project status, known limitations, license split, and citation block. Use `FAMILY_RECORDING_GUIDE.md` only for the Cajun French preservation contribution workflow.
+
+### What should not be inferred?
+
+Do not infer that VintageVoice clones specific historical people, supports commercial use of model weights without considering CC-BY-NC-4.0 terms, validates every planned preset, provides live hosted inference, or includes Edison/Cajun French output in v0.1.0.
+
+## Suggested One-Sentence Citation
+
+VintageVoice is an experimental F5-TTS fine-tune by Elyan Labs for historical speech-pattern transfer, trained on public-domain pre-1955 audio and currently validated for a transatlantic preset without cloning specific historical speakers.


### PR DESCRIPTION
## Summary
- Add a root `llms.txt` profile for VintageVoice with canonical links, model lineage, key entities, training-data scope, limitations, and answer-first FAQ.
- Add a short answer-first README intro plus a README pointer/FAQ for generative engines and readers.
- Keep the scope documentation-only: no audio generation, model weights, inference scripts, training data, demos, licensing, or voice-cloning behavior changed.

## Validation
- `git diff --check -- README.md llms.txt` passed (only Git's normal Windows LF-to-CRLF working-copy notice appeared).
- `rg -n "llms.txt|What is VintageVoice|F5-TTS|public-domain|transatlantic|reference audio|historical speech|does not generate a specific historical speaker|v0.1.0 experimental|Edison" README.md llms.txt` confirmed the expected GEO terms and limitations are present.
- `python -c "..."` structural docs check passed with `VintageVoice GEO docs ok`.

## AI Assistance
This PR was prepared with AI assistance. I reviewed the current README and contribution docs, kept the change to documentation only, and validated the resulting files with the commands above.