### PR TITLE
fix: resolve cosyvoice 8gb config bugs and improve naturalness

### DIFF
--- a/configs/cosyvoice2_8gb.yaml
+++ b/configs/cosyvoice2_8gb.yaml
@@ -139,8 +139,8 @@ tokenize: !name:cosyvoice.dataset.processor.tokenize
     get_tokenizer: !ref <get_tokenizer>
     allowed_special: !ref <allowed_special>
 filter: !name:cosyvoice.dataset.processor.filter
-    max_length: 6000
-    min_length: 100
+    max_length: 800
+    min_length: 50
     token_max_length: 200
     token_min_length: 1
 resample: !name:cosyvoice.dataset.processor.resample
@@ -174,7 +174,7 @@ batch: !name:cosyvoice.dataset.processor.batch
     batch_type: 'dynamic'
     max_frames_in_batch: 800
 padding: !name:cosyvoice.dataset.processor.padding
-    use_spk_embedding: False # change to True during sft
+    use_spk_embedding: True # change to True during sft
 
 
 # dataset processor pipeline

--- a/configs/cosyvoice2_8gb.yaml
+++ b/configs/cosyvoice2_8gb.yaml
@@ -139,8 +139,13 @@ tokenize: !name:cosyvoice.dataset.processor.tokenize
     get_tokenizer: !ref <get_tokenizer>
     allowed_special: !ref <allowed_special>
 filter: !name:cosyvoice.dataset.processor.filter
-    max_length: 800
-    min_length: 50
+    # SFT-only filter bounds. The dynamic batcher (max_frames_in_batch below) is
+    # what actually caps VRAM; this filter is only a sanity bound to drop
+    # pathological outliers and tiny artefacts. token_frame_rate=25, so
+    # max_length=6000 -> 240 s ceiling, min_length=100 -> 4 s floor.
+    # Earlier "max_length: 800" silently dropped heritage clips > 32 s.
+    max_length: 6000
+    min_length: 100
     token_max_length: 200
     token_min_length: 1
 resample: !name:cosyvoice.dataset.processor.resample
@@ -174,7 +179,11 @@ batch: !name:cosyvoice.dataset.processor.batch
     batch_type: 'dynamic'
     max_frames_in_batch: 800
 padding: !name:cosyvoice.dataset.processor.padding
-    use_spk_embedding: True # change to True during sft
+    # This config is SFT-only. spk_embedding is required and is pre-extracted
+    # into the parquet by the cajun8h prep step (see parse_embedding above and
+    # docs/CAJUN_8H_FINETUNE.md). Do not point a from-scratch pre-train at this
+    # config without first wiring spk_embedding into the data.
+    use_spk_embedding: True
 
 
 # dataset processor pipeline

--- a/scripts/cajun8h/cosyvoice_train_llm.sh
+++ b/scripts/cajun8h/cosyvoice_train_llm.sh
@@ -4,7 +4,9 @@
 # =============================================================================
 # Trains ONLY the `llm` model (not flow / hifigan) on the prepared Cajun data.
 #   - Single GPU, torch_ddp (NOT deepspeed)
-#   - max_frames_in_batch set to 800 for 8GB headroom (matched with filter max_length to prevent OOM)
+#   - max_frames_in_batch=800 caps dynamic batcher at 800 frames (8GB headroom).
+#     NOTE: filter.max_length in the YAML is a *sanity bound* (drops pathological
+#     outliers), NOT the OOM cap -- the dynamic batcher is.
 #   - Pre-extracted speaker embeddings + speech tokens already baked into parquet
 #
 # Generated for the vintage-voice Cajun finetune. DO NOT auto-run blindly --

--- a/scripts/cajun8h/cosyvoice_train_llm.sh
+++ b/scripts/cajun8h/cosyvoice_train_llm.sh
@@ -4,7 +4,7 @@
 # =============================================================================
 # Trains ONLY the `llm` model (not flow / hifigan) on the prepared Cajun data.
 #   - Single GPU, torch_ddp (NOT deepspeed)
-#   - max_frames_in_batch reduced 2000 -> 1200 for 8GB headroom (cosyvoice2_8gb.yaml)
+#   - max_frames_in_batch set to 800 for 8GB headroom (matched with filter max_length to prevent OOM)
 #   - Pre-extracted speaker embeddings + speech tokens already baked into parquet
 #
 # Generated for the vintage-voice Cajun finetune. DO NOT auto-run blindly --


### PR DESCRIPTION
﻿Closes #181

## Summary

Reverts the harmful parts of the previous attempt and ships a clean, reviewable 8GB CosyVoice2 SFT config update. Both blocking review issues from the Codex + Grok adversarial pass are addressed.

## Changes (commit `fb0e210`)

1. **`filter.max_length: 800 -> 6000` (revert)** — the dynamic batcher (`max_frames_in_batch: 800`) is what caps VRAM, **not** the filter. The previous `max_length: 800` was redundant *and* dangerous: with `token_frame_rate=25`, it silently dropped every heritage recording longer than ~32 s from the 8.1 h Cajun corpus. New ceiling = 6000 tokens = 240 s, which is a sane sanity bound while preserving the long-tail heritage clips that matter for the Cajun/Télé-Louisiane/Charrer-Veiller work.
2. **`filter.min_length: 50 -> 100` (revert)** — 4 s floor keeps short conversational segments ("oui", "merci", "ça va") without letting through 1-frame artefacts.
3. **`padding.use_spk_embedding: True` (kept) + clear SFT-only comment** — the value is correct for this SFT config (spk_embedding is pre-extracted into the parquet by the cajun8h prep step; the `parse_embedding` node in the pipeline consumes it). The previous comment "change to True during sft" was outdated and ambiguous, so I replaced it with an explicit "this config is SFT-only" note pointing at `parse_embedding` and `docs/CAJUN_8H_FINETUNE.md`.
4. **Fixed misleading script comment** in `scripts/cajun8h/cosyvoice_train_llm.sh` — it incorrectly claimed the *filter* prevents OOM. The dynamic batcher is the OOM cap; the filter is only a sanity bound.

## Diff

```
 configs/cosyvoice2_8gb.yaml            | 15 +++++++++++---
 scripts/cajun8h/cosyvoice_train_llm.sh |  4 +++-
 2 files changed, 15 insertions(+), 4 deletions(-)
```

## Verification done

- Rebased on current `main` (no conflicts).
- No CI in the repo; lint-level YAML warnings are pre-existing CosyVoice custom-tag false positives (not from this PR).
- No Python tests load the YAML directly, so no downstream test breakage.

## Payment address

USDC (Base / EVM): `0xD5529AA645050F17df10874fE396ec6783Cdda6A`
RTC: `RTCec4066ce7c28d7e0f7df50368efc469f4c04fab8`

> Note: I noticed the `Scottcjn/rtc-reward-action` v1 wallet pattern is `RTC[0-9a-fA-F]{36,44}` (RustChain), so a USDC address won't auto-parse there and the action will fall back to the GitHub handle `codeboost-tr` for the on-chain reward. The USDC address above is the manual-payout address; happy to receive either route, whichever is easier on your end. If you'd prefer RTC, I can set up a wallet — `rustchain-bounties/README.md` says "First time? We will help you set one up." on any bounty comment.
