### PR TITLE
lexicon: add 21 Louisiana French entries (food, expressions, place-names)

### DIFF
--- a/scripts/cajun8h/cajun_lexicon.py
+++ b/scripts/cajun8h/cajun_lexicon.py
@@ -159,6 +159,31 @@ LEXICON = {
     "Remi":         "Rémi",
     "Attakapas":    "Atakapa",
     "Acadie":       "Acadie",
+    # ---- Cajun kitchen / table (Daigle, A Dict. of the Cajun Language 1984;
+    #      Valdman et al., Dict. of Louisiana French 2010 — ear-tunable) ----
+    "jambalaya":     "jambalaïa",      # jahm-bah-LIE-ah (same -aya->-aïa as Atchafalaya)
+    "andouille":     "andouï",         # ahn-DOO-ee — smoked pork sausage (drop final schwa)
+    "andouilles":    "andouïs",
+    "maque choux":   "mak-chou",       # mock-SHOO — stewed corn dish
+    "sauce piquante":"sauce picante",  # sohss pee-KAHNT — tomato-pepper stew
+    "fricassée":     "fricassé",       # free-kah-SAY (same -ée->-é as étouffée->étouffé)
+    "filé":          "filé",           # FEE-lay — ground sassafras for gumbo
+    "tasso":         "tasso",          # TAH-so — cured smoked pork
+    # ---- everyday Cajun French (Daigle 1984; Valdman DLF 2010 — ear-tunable) ----
+    "mais oui":      "mè oui",         # may-WEE — "why yes / of course" (same mè- as "mais là")
+    "mais non":      "mè non",         # may-NOHN — "why no"
+    "icitte":        "icitte",         # ee-SEET — Cajun "here" (vs. textbook "ici")
+    "couillonnade":  "couyonade",      # koo-yoh-NAHD — foolishness (same root as couillon->couyon)
+    "couillonnades": "couyonades",
+    "bébête":        "bébête",         # bay-BET — critter / bug / bogeyman
+    "bébêtes":       "bébêtes",
+    "tonnerre":      "tonnerre",       # toh-NAIR — "thunder", common exclamation ("tonnerre m'écrase")
+    # ---- more place-names (USGS GNIS; local Louisiana French pronunciation) ----
+    "Des Allemands": "Dèz Almand",     # day-zal-MAHN — St. Charles/Lafourche town ("the Germans")
+    "Choupique":     "Choupique",      # shoo-PEEK — bayou/community + the bowfin fish
+    "Grosse Tête":   "Grosse Tête",    # grohs-TET — Iberville Parish town
+    "Arnaudville":   "Arnaudville",    # ar-no-VEEL — St. Landry/St. Martin town
+    "Bogalusa":      "Bogalouza",      # boh-gah-LOO-zah — Washington Parish town
     # ---- Sophia's own name, the Cajun way (ear-tunable) ----
     "Sophia Elya":  "Sofia Élia",
     "Elya":         "Élia",


### PR DESCRIPTION
Adds 21 regional pronunciation entries to `scripts/cajun8h/cajun_lexicon.py`, in the same French-orthography respell style as the existing map (keys = standard spelling, values = a Louisiana-French first-guess for CosyVoice2). Grouped into three commented sections with a one-line note per entry:

**Cajun kitchen / table**
- `jambalaya → jambalaïa` (same `-aya → -aïa` treatment as the existing `Atchafalaya → Atchafalaïa`)
- `andouille → andouï` (+ plural), `maque choux → mak-chou`, `sauce piquante → sauce picante`
- `fricassée → fricassé` (mirrors the existing `étouffée → étouffé`), `filé`, `tasso`

**Everyday Cajun French**
- `mais oui → mè oui`, `mais non → mè non` (same `mè-` elision as the existing `mais là → mè là`)
- `icitte` (Cajun "here"), `couillonnade → couyonade` (+ plural; same root as the existing `couillon → couyon`), `bébête` (+ plural), `tonnerre`

**Place-names**
- `Des Allemands → Dèz Almand`, `Choupique`, `Grosse Tête`, `Arnaudville`, `Bogalusa → Bogalouza`

### Attestation
Vocabulary entries are drawn from published Louisiana-French glossaries — Rev. Jules O. Daigle, *A Dictionary of the Cajun Language* (1984) and Valdman et al., *Dictionary of Louisiana French* (2010); place-names from USGS GNIS + local pronunciation. As the file header notes, these are French-friendly first-guesses meant to be refined by ear — happy to tweak any respelling you'd like tuned.

### Sanity
The module still imports cleanly and `respell()` / `to_js()` work; spot checks:
- `On va manger du jambalaya et de l'andouille, cher.` → `On va manger du jambalaïa et de l'andouï, sha.`
- `Mais oui, c'est une couillonnade icitte !` → `Mè oui, c'est une couyonade icitte !`
- `Passe par Des Allemands et Grosse Tête.` → `Passe par Dèz Almand et Grosse Tête.`

No entries duplicate existing keys; additions are append-only.

Closes #178

I'll share an RTC wallet address before merge.
