### PR TITLE
lexicon: add Cajun kinship, prairie/marsh land & fish/trapping terms …

### DIFF
--- a/scripts/cajun8h/cajun_lexicon.py
+++ b/scripts/cajun8h/cajun_lexicon.py
@@ -240,6 +240,39 @@ LEXICON = {
     "bête puante":  "bèt pwante",      # bet-PWANT — skunk ("stinking beast")
     "mulet":        "mulè",            # mu-LAY — mullet (silent t)
     "soulard":      "soula",           # soo-LAH — drunkard (silent r-d)
+    # ---- kinship & terms of address (Daigle, "A Dictionary of the Cajun
+    #      Language" 1984; Valdman et al., "Dictionary of Louisiana French" 2010
+    #      — ear-tunable) ----
+    "parrain":      "parran",      # pa-RAN — godfather (drop the textbook -ain glide)
+    "marraine":     "marenne",     # ma-REN — godmother
+    "nénaine":      "nénenne",     # nay-NEN — godmother (Cajun affectionate form)
+    "mononc":       "mononk",      # moh-NONK — uncle ("mon oncle" fused; cf. "nonc")
+    "matante":      "matante",     # ma-TANT — auntie ("ma tante" fused)
+    "popa":         "popa",        # poh-PAH — papa / dad
+    "moman":        "moman",       # moh-MAHN — mama / mom
+    "bougre":       "bougue",      # BOOG — fellow / guy (drop the -re)
+    "bougres":      "bougues",
+    "vaillant":     "vayan",       # vah-YAHN — brave, hardworking (a term of praise)
+    "vaillante":    "vayante",
+    # ---- prairie, marsh & bayou land (USGS GNIS feature terms; Valdman DLF 2010) ----
+    "coulée":       "coulé",       # koo-LAY — gully / seasonal stream (cf. étouffée->étouffé)
+    "coulées":      "coulés",
+    "platin":       "platin",      # plah-TANH — low wet spot that holds water in a field
+    "trainasse":    "trénasse",    # tray-NAHSS — trapper's narrow channel cut through marsh
+    "trénasse":     "trénasse",    # spelling variant
+    "batture":      "batture",     # bah-TUR — land between the levee and the river
+    "chénière":     "chénière",    # shay-NYAIR — live-oak ridge in the marsh (Chénière au Tigre)
+    "cheniere":     "chénière",    # ascii-typed variant
+    "marais":       "marè",        # mah-REH — marsh (silent -s)
+    "anse":         "anse",        # AHNSS — cove / inlet (Anse La Butte, Grand Anse)
+    # ---- fish & trapping animals (Daigle 1984; Valdman DLF 2010 — ear-tunable) ----
+    "sac-à-lait":   "sac-à-lè",    # sak-ah-LEH — white crappie ("milk sack")
+    "sac à lait":   "sac-à-lè",    # spacing variant
+    "patassa":      "patassa",     # pah-tah-SAH — sunfish / perch
+    "rat de bois":  "rat d'bois",  # rah-d-BWAH — opossum ("woods rat")
+    "rat musqué":   "rat musqué",  # rah moos-KAY — muskrat (the prized trapping animal)
+    "tortue":       "tortu",       # tor-TU — turtle (silent -e)
+    "tortues":      "tortus",
 }
 
 _lower_index = {k.lower(): v for k, v in LEXICON.items()}


### PR DESCRIPTION
Third batch for the Louisiana / Cajun pronunciation lexicon in `scripts/cajun8h/cajun_lexicon.py` (`#178`). Append-only, same French-orthography "drop the textbook tail" style as the existing entries, each with a short respelling note and grouped into three labelled sections. 28 new keys (variants included).

**Kinship & terms of address** — `parrain` → `parran`, `marraine` → `marenne`, `nénaine` → `nénenne` (the affectionate Cajun godmother), `mononc`/`matante` (the fused "mon oncle"/"ma tante"), `popa`, `moman`, `bougre` → `bougue`, `vaillant` → `vayan`.

**Prairie, marsh & bayou land** — the everyday Louisiana-French landscape nouns you hit in place-names and conversation: `coulée` → `coulé`, `platin`, `trainasse` → `trénasse` (a trapper's cut through the marsh), `batture`, `chénière` (the live-oak ridges, e.g. Chénière au Tigre), `marais` → `marè`, `anse`.

**Fish & trapping animals** — `sac-à-lait` → `sac-à-lè` (white crappie), `patassa` (sunfish/perch), `rat de bois` (opossum), `rat musqué` (muskrat), `tortue` → `tortu`.

Sources / attestation: Daigle, *A Dictionary of the Cajun Language* (1984); Valdman et al., *Dictionary of Louisiana French as Spoken in Cajun, Creole and American Indian Communities* (2010); USGS GNIS for the land/feature terms. No scraped or rights-encumbered audio — these are text respellings of well-documented vocabulary.

Sanity-checked locally: the module imports, `respell()` applies the new entries (e.g. "On a passé la coulée … du sac-à-lait. Mon parrain dit mais oui." → "… la coulé … du sac-à-lè. Mon parran dit mais oui."), and `to_js()` still emits cleanly. No existing keys touched.

Closes #178

/claim #178

I'll share an RTC wallet address before merge.
