### PR TITLE
lexicon: add Cajun religion/holidays, weather & expression respellings (#178)

### DIFF
--- a/scripts/cajun8h/cajun_lexicon.py
+++ b/scripts/cajun8h/cajun_lexicon.py
@@ -240,6 +240,32 @@ LEXICON = {
     "bête puante":  "bèt pwante",      # bet-PWANT — skunk ("stinking beast")
     "mulet":        "mulè",            # mu-LAY — mullet (silent t)
     "soulard":      "soula",           # soo-LAH — drunkard (silent r-d)
+    # ---- religion, holidays & the faith ----
+    "Toussaint":       "Toussan",      # All Saints' Day, "too-SAN" — Valdman, Dict. of La. French (DLF) 2010
+    "Pâques":          "Pâk",          # Easter, "pahk" (final -s silent) — DLF
+    "Paques":          "Pâk",          # ascii-typed variant
+    "Carême":          "Carèm",        # Lent, "ka-REM" — DLF
+    "Careme":          "Carèm",        # ascii-typed variant
+    "réveillon":       "révéyon",      # Christmas / New-Year night feast, "ray-vay-YOHN" — DLF
+    "reveillon":       "révéyon",      # ascii-typed variant
+    "Vendredi Saint":  "Vendredi San", # Good Friday, "vahn-druh-dee-SAN" — DLF
+    "messe de minuit": "mess de minwi",# midnight Mass, "mess-duh-mee-NWEE" — Ancelet
+    "bon Dieu":        "bon Djeu",     # "good Lord" — Cajun palatalizes Dieu to "djeu" — Ancelet
+    "Mardi Gras":      "Mardi Gra",    # "mar-dee-GRAH" (final -s silent) — DLF
+    # ---- weather, water & the wild ----
+    "suroît":          "surwa",        # southwest wind, "su-RWA" (oî->wa, final t silent) — DLF
+    "suroit":          "surwa",        # ascii-typed variant
+    "crapaud":         "crapo",        # toad/frog, "kra-PO" — Daigle 1984
+    "crapauds":        "crapo",
+    "mouche à feu":    "mouch à feu",  # firefly, "moosh-a-FEU" — DLF
+    "au ras":          "o ra",         # right beside / close to, "o-RA" — DLF
+    # ---- time & everyday turns of phrase ----
+    "tantôt":          "tantô",        # a while ago / later on, "tahn-TOH" — DLF
+    "tantot":          "tantô",        # ascii-typed variant
+    "bêtise":          "bétiz",        # nonsense / foolishness, "bay-TEEZ" — DLF
+    "betise":          "bétiz",        # ascii-typed variant
+    "lâche pas la patate": "lâche pa la patat",  # "don't drop the potato" = don't give up — Ancelet
+    "lache pas la patate": "lâche pa la patat",  # ascii-typed variant
 }
 
 _lower_index = {k.lower(): v for k, v in LEXICON.items()}


### PR DESCRIPTION
Fourth batch for the Cajun pronunciation lexicon in `scripts/cajun8h/cajun_lexicon.py`, per the per-PR bounty in #178. Append-only — 23 new keys, no existing entry touched. Themes are distinct from my earlier batches (#186 food/expressions/place-names, #187 music/Mardi-Gras/critters, #188 kinship/prairie-marsh/fish):

**Religion, holidays & the faith**
`Toussaint`→Toussan, `Pâques`/`Paques`→Pâk, `Carême`/`Careme`→Carèm, `réveillon`/`reveillon`→révéyon, `Vendredi Saint`→Vendredi San, `messe de minuit`→mess de minwi, `bon Dieu`→bon Djeu, `Mardi Gras`→Mardi Gra.

**Weather, water & the wild**
`suroît`/`suroit`→surwa (SW wind), `crapaud`/`crapauds`→crapo, `mouche à feu`→mouch à feu (firefly), `au ras`→o ra.

**Time & everyday turns of phrase**
`tantôt`/`tantot`→tantô, `bêtise`/`betise`→bétiz, `lâche pas la patate`→lâche pa la patat.

Each entry carries a one-line phonetic note. The respellings follow the same French-orthography-first style already in the file (final silent consonants dropped, `oî`→`wa`, `Dieu`→`Djeu` palatalization, etc.), tunable by ear.

**Sources:** Valdman et al., *Dictionary of Louisiana French* (2010); Daigle, *A Dictionary of the Cajun Language* (1984); Ancelet, *Cajun and Creole Folktales* / *Cajun Music* for the festive/faith vocabulary.

**Validated locally before pushing:**
- module imports clean; `LEXICON` grows 171 → 194 keys, **0 collisions** with existing keys (checked against current `main` + my open PRs #186/#187/#188).
- `respell()` smoke-tests correct, e.g. *"Le réveillon après la messe de minuit, pour Pâques et Toussaint"* → *"Le révéyon après la mess de minwi, pour Pâk et Toussan"*.
- `to_js()` still emits the website map without error.

Closes #178

/claim #178

I'll share an RTC wallet address before merge if you need it for payout.
