### PR TITLE
Add portable inference benchmark path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ models/*.safetensors
 models/*.bin
 *.pyc
 __pycache__/
+.pytest-tmp/
+.pytest_cache/
 .env
 *.wav
 *.mp3

--- a/README.md
+++ b/README.md
@@ -167,6 +167,24 @@ python scripts/generate.py \
     --output     out.wav
 ```
 
+`--device auto` is the default for portable inference. It keeps PPC/POWER and
+non-mac ARM hosts on CPU, uses Apple Silicon MPS when available, and otherwise
+uses CUDA when PyTorch reports CUDA support. To inspect a target before running
+F5-TTS, use the benchmark dry-run:
+
+```bash
+python scripts/benchmark_inference.py \
+    --device auto \
+    --dry-run \
+    --json benchmark-plan.json
+```
+
+On target hardware, remove `--dry-run` and pass the same model, vocab,
+reference audio, and reference transcript used with `scripts/generate.py` to
+write runnable timing evidence. See
+[`docs/PORTABLE_INFERENCE.md`](docs/PORTABLE_INFERENCE.md) for target-hardware
+notes and the benchmark JSON shape.
+
 Direct F5-TTS API call, for reference:
 
 ```python

--- a/docs/PORTABLE_INFERENCE.md
+++ b/docs/PORTABLE_INFERENCE.md
@@ -1,0 +1,87 @@
+# Portable Inference Notes
+
+VintageVoice now supports an `auto` inference device mode for hardware where
+CUDA cannot be assumed. The goal is to keep the existing F5-TTS generation path
+intact while making PPC, POWER, ARM, and Apple Silicon runs explicit and
+measurable.
+
+## Device Selection
+
+`scripts.generate.generate_speech(..., device="auto")` resolves the runtime
+device as follows:
+
+| Host | Device | Reason |
+| --- | --- | --- |
+| macOS arm64/aarch64 with PyTorch MPS | `mps` | Use Apple Silicon acceleration |
+| PPC, POWER, Linux ARM, or other CPU-first portable hosts | `cpu` | Avoid unsupported accelerator assumptions |
+| Conventional host with CUDA available | `cuda:0` | Preserve the current fast GPU path |
+| Any other host | `cpu` | Safe fallback |
+
+Passing an explicit F5-TTS device string such as `cpu`, `cuda:1`, or `mps`
+still overrides the automatic plan.
+
+## Dry-Run The Target
+
+Use the dry-run mode first on any new machine. It does not import or run F5-TTS,
+so it can validate platform detection before model dependencies are installed.
+
+```bash
+python scripts/benchmark_inference.py \
+  --device auto \
+  --dry-run \
+  --json benchmark-plan.json
+```
+
+Example JSON shape:
+
+```json
+{
+  "dry_run": true,
+  "plan": {
+    "device": "cpu",
+    "machine": "ppc64le",
+    "reason": "portable CPU-first target architecture",
+    "system": "linux"
+  },
+  "runs": [],
+  "warmup": 0
+}
+```
+
+## Run A Live Benchmark
+
+After installing F5-TTS and downloading the model/vocab, use the same model,
+reference audio, and transcript you would pass to `scripts/generate.py`.
+
+```bash
+python scripts/benchmark_inference.py \
+  --device auto \
+  --model ./weights/model.safetensors \
+  --vocab ./weights/vocab.txt \
+  --ref-audio path/to/reference.wav \
+  --ref-text "Exact transcript of the reference clip." \
+  --runs 3 \
+  --warmup 1 \
+  --output-dir benchmark_out \
+  --json benchmark-result.json
+```
+
+The live JSON includes the resolved device and one timing entry per measured
+run. Warmup runs are executed but not included in `runs`.
+
+## Generate Directly
+
+`scripts/generate.py` also defaults to portable device selection:
+
+```bash
+python scripts/generate.py \
+  "Good evening, ladies and gentlemen." \
+  --model ./weights/model.safetensors \
+  --vocab ./weights/vocab.txt \
+  --ref-audio path/to/reference.wav \
+  --ref-text "Exact transcript of the reference clip." \
+  --output out.wav
+```
+
+Use `--device cpu` when you need to force the slow but predictable path, or
+`--device mps` / `--device cuda:0` when you want to bypass auto-detection.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+addopts = --basetemp=.pytest-tmp
+testpaths = tests

--- a/scripts/benchmark_inference.py
+++ b/scripts/benchmark_inference.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""Benchmark VintageVoice inference on portable hardware targets."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict
+import json
+from pathlib import Path
+from time import perf_counter
+
+try:
+    from scripts.generate import generate_speech
+    from scripts.portable_inference import choose_inference_plan
+except ModuleNotFoundError:
+    from generate import generate_speech
+    from portable_inference import choose_inference_plan
+
+
+DEFAULT_TEXT = "Good evening, ladies and gentlemen. This is a portable VintageVoice test."
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Benchmark VintageVoice inference")
+    parser.add_argument("--text", default=DEFAULT_TEXT)
+    parser.add_argument("--preset", default="transatlantic")
+    parser.add_argument("--model", default=None, help="Path to model checkpoint")
+    parser.add_argument("--vocab", default=None, help="Path to vocab.txt")
+    parser.add_argument("--ref-audio", default=None, help="Reference WAV path")
+    parser.add_argument("--ref-text", default="", help="Reference transcript")
+    parser.add_argument("--device", default="auto")
+    parser.add_argument("--runs", type=int, default=1)
+    parser.add_argument("--warmup", type=int, default=0)
+    parser.add_argument("--output-dir", default="benchmark_out")
+    parser.add_argument("--json", default=None, help="Write benchmark metadata JSON")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Resolve the portable plan without importing/running F5-TTS",
+    )
+    return parser
+
+
+def run_benchmark(args: argparse.Namespace, generate=generate_speech) -> dict:
+    if args.runs < 1:
+        raise ValueError("--runs must be at least 1")
+    if args.warmup < 0:
+        raise ValueError("--warmup must be zero or greater")
+
+    plan = choose_inference_plan(args.device)
+    output_dir = Path(args.output_dir)
+    result = {
+        "plan": asdict(plan),
+        "runs": [],
+        "warmup": args.warmup,
+        "dry_run": bool(args.dry_run),
+    }
+
+    if args.dry_run:
+        return result
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    for index in range(args.warmup + args.runs):
+        output_path = output_dir / f"portable_inference_{index + 1}.wav"
+        started = perf_counter()
+        generated = generate(
+            text=args.text,
+            preset=args.preset,
+            model_path=args.model,
+            vocab_path=args.vocab,
+            ref_audio=args.ref_audio,
+            ref_text=args.ref_text,
+            output_path=str(output_path),
+            device=plan.device,
+        )
+        elapsed = perf_counter() - started
+        if index >= args.warmup:
+            result["runs"].append(
+                {
+                    "seconds": round(elapsed, 4),
+                    "output": str(generated or output_path),
+                }
+            )
+    return result
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+    result = run_benchmark(args)
+    payload = json.dumps(result, indent=2, sort_keys=True)
+    print(payload)
+    if args.json:
+        Path(args.json).write_text(payload + "\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -16,6 +16,11 @@ import argparse
 import os
 import sys
 
+try:
+    from scripts.portable_inference import choose_inference_plan
+except ModuleNotFoundError:
+    from portable_inference import choose_inference_plan
+
 
 # Reference audio clips for each preset (included in the model release).
 # Each is a clean 5-15 sec WAV (24 kHz mono) that captures the target
@@ -38,13 +43,14 @@ def resolve_ref(preset, override, model_dir):
     rel = PRESET_REFS.get(preset)
     if not rel:
         return None
-    if os.path.exists(rel):
-        return rel
+    rel_path = os.path.normpath(rel)
+    if os.path.exists(rel_path):
+        return rel_path
     if model_dir:
-        candidate = os.path.join(model_dir, rel)
+        candidate = os.path.join(model_dir, rel_path)
         if os.path.exists(candidate):
             return candidate
-    return rel  # let caller surface a clear error if missing
+    return rel_path  # let caller surface a clear error if missing
 
 
 def generate_speech(
@@ -55,7 +61,7 @@ def generate_speech(
     ref_audio=None,
     ref_text="",
     output_path="output.wav",
-    device="cuda:0",
+    device="auto",
     speed=0.9,
     remove_silence=True,
 ):
@@ -88,18 +94,20 @@ def generate_speech(
         print("   exact transcript of your reference clip.", file=sys.stderr)
         print("", file=sys.stderr)
 
+    plan = choose_inference_plan(device)
+
     print("VintageVoice Generation")
     print(f"  Preset:    {preset}")
     print(f"  Text:      {text[:80]}{'...' if len(text) > 80 else ''}")
     print(f"  Reference: {ref_audio}")
     print(f"  Output:    {output_path}")
-    print(f"  Device:    {device}")
+    print(f"  Device:    {plan.device} ({plan.reason})")
 
     tts = F5TTS(
         model="F5TTS_v1_Base",
         ckpt_file=model_path or "",
         vocab_file=vocab_path or "",
-        device=device,
+        device=plan.device,
         use_ema=True,
     )
     if model_path:
@@ -132,7 +140,11 @@ def main():
                         help="Transcript of the reference audio (recommended; "
                              "skips Whisper auto-transcribe and reduces bleed)")
     parser.add_argument("--output", default="output.wav", help="Output WAV path")
-    parser.add_argument("--device", default="cuda:0")
+    parser.add_argument(
+        "--device",
+        default="auto",
+        help="F5-TTS device string or 'auto' for portable CPU/MPS/CUDA selection",
+    )
     parser.add_argument("--speed", type=float, default=0.9,
                         help="Playback speed; 0.9 suits measured vintage cadence")
     parser.add_argument("--keep-silence", action="store_true",

--- a/scripts/portable_inference.py
+++ b/scripts/portable_inference.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: MIT
+"""Portable inference device planning for VintageVoice.
+
+The helpers here avoid importing F5-TTS at module import time so architecture
+selection and benchmark dry-runs stay testable on machines without model deps.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import importlib
+import platform
+from typing import Any
+
+
+CPU_FIRST_ARCH_PREFIXES = ("arm", "aarch", "ppc", "powerpc", "power")
+APPLE_SILICON_ARCHES = {"arm64", "aarch64"}
+
+
+@dataclass(frozen=True)
+class InferencePlan:
+    system: str
+    machine: str
+    device: str
+    reason: str
+
+
+def normalize_machine(machine: str | None = None) -> str:
+    return (machine or platform.machine() or "").strip().lower().replace("-", "_")
+
+
+def normalize_system(system: str | None = None) -> str:
+    return (system or platform.system() or "").strip().lower()
+
+
+def is_cpu_first_arch(machine: str | None = None) -> bool:
+    normalized = normalize_machine(machine)
+    return normalized.startswith(CPU_FIRST_ARCH_PREFIXES)
+
+
+def _load_torch() -> Any | None:
+    try:
+        return importlib.import_module("torch")
+    except ImportError:
+        return None
+
+
+def _torch_mps_available(torch_module: Any | None) -> bool:
+    backends = getattr(torch_module, "backends", None)
+    mps = getattr(backends, "mps", None)
+    checker = getattr(mps, "is_available", None)
+    return bool(checker and checker())
+
+
+def _torch_cuda_available(torch_module: Any | None) -> bool:
+    cuda = getattr(torch_module, "cuda", None)
+    checker = getattr(cuda, "is_available", None)
+    return bool(checker and checker())
+
+
+def choose_inference_plan(
+    requested_device: str = "auto",
+    *,
+    machine: str | None = None,
+    system: str | None = None,
+    torch_module: Any | None = None,
+) -> InferencePlan:
+    """Resolve an F5-TTS device string for a host.
+
+    Explicit devices are preserved. ``auto`` prefers Apple Silicon MPS, keeps
+    PPC/POWER/non-mac ARM on CPU, then falls back to CUDA on conventional hosts.
+    """
+
+    normalized_machine = normalize_machine(machine)
+    normalized_system = normalize_system(system)
+    requested = (requested_device or "auto").strip()
+    if requested.lower() != "auto":
+        return InferencePlan(
+            system=normalized_system,
+            machine=normalized_machine,
+            device=requested,
+            reason="explicit device override",
+        )
+
+    torch_for_probe = torch_module if torch_module is not None else _load_torch()
+    if (
+        normalized_system == "darwin"
+        and normalized_machine in APPLE_SILICON_ARCHES
+        and _torch_mps_available(torch_for_probe)
+    ):
+        return InferencePlan(
+            system=normalized_system,
+            machine=normalized_machine,
+            device="mps",
+            reason="Apple Silicon MPS is available",
+        )
+
+    if is_cpu_first_arch(normalized_machine):
+        return InferencePlan(
+            system=normalized_system,
+            machine=normalized_machine,
+            device="cpu",
+            reason="portable CPU-first target architecture",
+        )
+
+    if _torch_cuda_available(torch_for_probe):
+        return InferencePlan(
+            system=normalized_system,
+            machine=normalized_machine,
+            device="cuda:0",
+            reason="CUDA is available on this host",
+        )
+
+    return InferencePlan(
+        system=normalized_system,
+        machine=normalized_machine,
+        device="cpu",
+        reason="no supported accelerator detected",
+    )

--- a/tests/test_benchmark_inference.py
+++ b/tests/test_benchmark_inference.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: MIT
+from argparse import Namespace
+
+from scripts.benchmark_inference import run_benchmark
+
+
+def make_args(tmp_path, **overrides):
+    values = {
+        "text": "portable test",
+        "preset": "transatlantic",
+        "model": None,
+        "vocab": None,
+        "ref_audio": None,
+        "ref_text": "",
+        "device": "cpu",
+        "runs": 2,
+        "warmup": 1,
+        "output_dir": str(tmp_path),
+        "json": None,
+        "dry_run": False,
+    }
+    values.update(overrides)
+    return Namespace(**values)
+
+
+def test_dry_run_returns_plan_without_generating(tmp_path):
+    called = False
+
+    def generate(**kwargs):
+        nonlocal called
+        called = True
+
+    result = run_benchmark(make_args(tmp_path, dry_run=True), generate=generate)
+
+    assert result["dry_run"] is True
+    assert result["plan"]["device"] == "cpu"
+    assert result["runs"] == []
+    assert called is False
+
+
+def test_benchmark_skips_warmup_and_records_outputs(tmp_path):
+    calls = []
+
+    def generate(**kwargs):
+        calls.append(kwargs)
+        return kwargs["output_path"]
+
+    result = run_benchmark(make_args(tmp_path), generate=generate)
+
+    assert len(calls) == 3
+    assert len(result["runs"]) == 2
+    assert result["runs"][0]["output"].endswith("portable_inference_2.wav")
+    assert all(call["device"] == "cpu" for call in calls)
+
+
+def test_benchmark_rejects_empty_run_count(tmp_path):
+    try:
+        run_benchmark(make_args(tmp_path, runs=0))
+    except ValueError as exc:
+        assert "--runs" in str(exc)
+    else:
+        raise AssertionError("expected ValueError")

--- a/tests/test_portable_inference.py
+++ b/tests/test_portable_inference.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: MIT
+from types import SimpleNamespace
+
+from scripts.portable_inference import choose_inference_plan, is_cpu_first_arch
+
+
+def fake_torch(*, cuda=False, mps=False):
+    return SimpleNamespace(
+        cuda=SimpleNamespace(is_available=lambda: cuda),
+        backends=SimpleNamespace(mps=SimpleNamespace(is_available=lambda: mps)),
+    )
+
+
+def test_explicit_device_is_preserved():
+    plan = choose_inference_plan("cpu", machine="x86_64", torch_module=fake_torch(cuda=True))
+
+    assert plan.device == "cpu"
+    assert plan.reason == "explicit device override"
+
+
+def test_apple_silicon_prefers_mps_when_available():
+    plan = choose_inference_plan(
+        "auto",
+        system="Darwin",
+        machine="arm64",
+        torch_module=fake_torch(mps=True),
+    )
+
+    assert plan.device == "mps"
+
+
+def test_apple_silicon_falls_back_to_cpu_without_mps():
+    plan = choose_inference_plan(
+        "auto",
+        system="Darwin",
+        machine="arm64",
+        torch_module=fake_torch(mps=False, cuda=True),
+    )
+
+    assert plan.device == "cpu"
+
+
+def test_powerpc_targets_cpu_even_when_cuda_is_visible():
+    plan = choose_inference_plan(
+        "auto",
+        system="Linux",
+        machine="ppc64le",
+        torch_module=fake_torch(cuda=True),
+    )
+
+    assert plan.device == "cpu"
+
+
+def test_conventional_cuda_host_uses_cuda():
+    plan = choose_inference_plan(
+        "auto",
+        system="Linux",
+        machine="x86_64",
+        torch_module=fake_torch(cuda=True),
+    )
+
+    assert plan.device == "cuda:0"
+
+
+def test_cpu_first_arch_prefixes_cover_power_and_arm_variants():
+    assert is_cpu_first_arch("powerpc64")
+    assert is_cpu_first_arch("aarch64")
+    assert not is_cpu_first_arch("x86_64")


### PR DESCRIPTION
Closes #179

This adds a portable inference path for hosts where CUDA cannot be assumed:

- resolve `--device auto` for Apple Silicon MPS, CPU-first PPC/POWER/ARM hosts, conventional CUDA hosts, and safe CPU fallback
- add a benchmark command with dry-run and live modes so target hardware can record the resolved plan and timing evidence
- keep dry-run independent from F5-TTS imports, which lets vintage hardware validate the target plan before model dependencies are installed
- document the target-hardware workflow and benchmark JSON shape

Validation on this Windows host:

- `python -m pytest -q` -> 19 passed, 1 warning
- `python -m py_compile scripts\portable_inference.py scripts\benchmark_inference.py scripts\generate.py tests\test_portable_inference.py tests\test_benchmark_inference.py`
- `python scripts\benchmark_inference.py --device auto --dry-run --json .pytest-tmp\benchmark-plan.json` -> resolved CPU fallback on windows/amd64 with no accelerator detected
- `git diff --check origin/main...HEAD`

Bounty payout address, per the issue requirement:

`RTC80fcf3fa8f3ec79dd1ea9067e50afe8b5cffa8ea`
