### PR TITLE
lexicon: add Cajun surname respellings (#178)

### DIFF
--- a/scripts/cajun8h/cajun_lexicon.py
+++ b/scripts/cajun8h/cajun_lexicon.py
@@ -196,6 +196,23 @@ LEXICON = {
     "Sophia Elya":  "Sofia Élia",
     "Elya":         "Élia",
     "Sophia":       "Sofia",
+    # ---- Cajun / Acadian surnames (Louisiana surname rankings + Acadian family lists) ----
+    "Comeaux":      "Como",            # -eaux family-name ending: enforce the Cajun "o" sound
+    "Arceneaux":    "Arsenô",          # common Acadian/Cajun surname; same -eaux -> o pattern
+    "Robichaux":    "Robicho",
+    "Broussard":    "Broussar",        # final consonant softened/silent in French-friendly TTS
+    "Fontenot":     "Fontenô",         # Louisiana surname; final -ot rendered as open "o"
+    "Landry":       "Landri",
+    "LeBlanc":      "Le Blan",         # final c silent in French-style surname pronunciation
+    "Dugas":        "Duga",            # final s silent
+    "Doucet":       "Doucé",           # -cet family-name ending, closer to "doo-say"
+    "Bourgeois":    "Bourjwa",         # French oi -> wa
+    "Richard":      "Richar",          # final d silent
+    "Thériot":      "Tério",
+    "Theriot":      "Tério",
+    "Sonnier":      "Sonyé",
+    "Melançon":     "Mélançon",
+    "Melancon":     "Mélançon",
 }
 
 _lower_index = {k.lower(): v for k, v in LEXICON.items()}

--- a/tests/test_cajun_lexicon.py
+++ b/tests/test_cajun_lexicon.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: MIT
+from scripts.cajun8h.cajun_lexicon import respell, to_js
+
+
+def test_respell_cajun_surnames_uses_acadian_family_name_entries():
+    text = "Comeaux, Arceneaux, Broussard, Fontenot, and Bourgeois arrived."
+
+    assert (
+        respell(text)
+        == "Como, Arsenô, Broussar, Fontenô, and Bourjwa arrived."
+    )
+
+
+def test_respell_cajun_surnames_keeps_ascii_variants_and_capitalization():
+    text = "LeBlanc met Theriot, Sonnier, Doucet, Dugas, and Richard."
+
+    assert (
+        respell(text)
+        == "Le Blan met Tério, Sonyé, Doucé, Duga, and Richar."
+    )
+
+
+def test_cajun_lexicon_js_export_includes_new_entries():
+    js = to_js()
+
+    assert '"Comeaux": "Como"' in js
+    assert '"Bourgeois": "Bourjwa"' in js


### PR DESCRIPTION
## Summary
- Adds an append-only Cajun/Acadian surname batch to `scripts/cajun8h/cajun_lexicon.py`.
- Covers common Louisiana/Acadian surnames including Comeaux, Arceneaux, Robichaux, Broussard, Fontenot, Landry, LeBlanc, Dugas, Doucet, Bourgeois, Richard, Theriot/Thériot, Sonnier, and Melancon/Melançon.
- Adds pytest-style coverage for `respell()` and `to_js()` following the existing test style in this repository.

## Source / attestation
This batch uses public surname/family-name references as the one-line source basis requested in #178:
- Geneanet Louisiana surname list: https://en.geneanet.org/surnames/list/browse-region/USA/LOU?sort=alpha
- Acadian-Cajun surnames list: https://freepages.rootsweb.com/~acadiancajun/genealogy/surnames.htm

Respellings follow conventions already present in the lexicon, such as `-eaux` family-name endings using an "o" sound and final French consonants being softened or silent where appropriate. No audio, scraped material, or rights-encumbered media is included.

## Bounty
Closes #178

Bounty terms checked: 15 RTC/PR, paid per merged PR, PR must reference the issue and include an RTC wallet address.

RTC wallet address: `RTCde409a83a31e54f946144390eaeb9964a444d2e6`

## Validation
- `python3 - <<'PY' ...` direct assertions for `tests/test_cajun_lexicon.py` passed.
- `python3 -m compileall -q scripts/cajun8h/cajun_lexicon.py tests/test_cajun_lexicon.py` passed.
- `git diff --check` passed.
- `python3 -m pytest tests/test_cajun_lexicon.py tests/test_transatlantic_spelling.py -q` could not run in this local Python because `pytest` is not installed (`No module named pytest`).
