### PR TITLE
lexicon: add Cajun waterwork respellings

### DIFF
--- a/scripts/cajun8h/cajun_lexicon.py
+++ b/scripts/cajun8h/cajun_lexicon.py
@@ -132,6 +132,25 @@ LEXICON = {
     "cooshcoosh":   "couche-couche",
     "tracas":       "traca",           # trah-KAH — trouble / fuss / worries (silent s)
     "thraca":       "traca",
+    # ---- bayou boats, water & fishing-work terms (LSU glossary + public LA travel glossaries) ----
+    "bayou":        "baïou",           # Visit Baton Rouge: bayou = slow-moving stream, "bye-you"
+    "bayous":       "baïous",
+    "pirogue":      "pi-ro",           # Explore Louisiana/Acadiana Table: Cajun canoe, PEE-row
+    "pirogues":     "pi-ros",
+    "à la pêche":   "à la pèch",       # LSU Cajun glossary: pêche = fishing; final e softened
+    "a la peche":   "à la pèch",
+    "pêche":        "pèch",
+    "peche":        "pèch",
+    "eau douce":    "eau dous",        # LSU glossary: eau douce = fresh water, douce [DOOS]
+    "eaux douces":  "eaux dous",
+    "eau salée":    "eau salé",        # LSU glossary: eau salée = salt water; final e not over-read
+    "eau salee":    "eau salé",
+    "eaux salées":  "eaux salés",
+    "eaux salees":  "eaux salés",
+    "ecrevisse":    "écrevisse",       # LSU glossary: écrevisse = crawfish; keep accent in generated text
+    "ecrevisses":   "écrevisses",
+    "crevette":     "chevrette",       # LSU glossary notes Louisiana French chevrette for shrimp
+    "crevettes":    "chevrettes",
     # ---- St. Landry / prairie-Cajun colloquial (deep-research 2026-06-16) ----
     "asteur":       "asteur",          # ah-STUR — "now" (from à cette heure)
     "astheure":     "asteur",

--- a/tests/test_cajun_lexicon.py
+++ b/tests/test_cajun_lexicon.py
@@ -1,0 +1,22 @@
+from scripts.cajun8h.cajun_lexicon import LEXICON, respell, to_js
+
+
+def test_bayou_boat_and_fishing_terms_are_respelled():
+    text = "On prend la pirogue dans le bayou pour aller à la pêche."
+
+    assert respell(text) == "On prend la pi-ro dans le baïou pour aller à la pèch."
+
+
+def test_water_and_shrimp_terms_include_ascii_variants():
+    text = "Les crevettes dans l'eau salee et les crevette dans l'eau douce."
+
+    assert respell(text) == "Les chevrettes dans l'eau salé et les chevrette dans l'eau dous."
+
+
+def test_cajun_lexicon_js_export_includes_new_entries():
+    emitted = to_js()
+
+    assert LEXICON["pirogue"] == "pi-ro"
+    assert LEXICON["crevette"] == "chevrette"
+    assert '"pirogue": "pi-ro"' in emitted
+    assert '"crevette": "chevrette"' in emitted


### PR DESCRIPTION
## Summary

- Adds an append-only Cajun/Louisiana French waterwork batch to `scripts/cajun8h/cajun_lexicon.py`.
- Covers bayou/boat/fishing terms: `bayou`, `pirogue`, `à la pêche`, fresh/salt water phrases, crawfish accent variants, and `crevette` -> `chevrette` for Louisiana French shrimp wording.
- Adds focused regression coverage for `respell()` and `to_js()`.

## Source / attestation

- LSU Cajun French-English Glossary: source basis for `pêche`, `eau douce`, `eau salée`, `écrevisse`, and `chevrette` as Louisiana French shrimp wording.
- Explore Louisiana and Acadiana Table public glossaries: source basis for `pirogue` as the South Louisiana/Cajun canoe term and the `PEE-row` pronunciation.
- Visit Baton Rouge Cajun French dictionary: source basis for `bayou` as a slow-moving stream and the local `bye-you` pronunciation cue.

These are text respellings only. No scraped audio or rights-encumbered media is included.

## Bounty

Closes #178

RTC wallet address: `RTCd1acb2189e9f36df2b5393c3c27a867c3c32b116`

## Validation

- `python3 - <<'PY' ...` AST duplicate-key check: `lexicon entries=189 duplicates=[]`
- `python3 - <<'PY' ...` direct test-function execution: 3 passed
- `python3 -m compileall -q scripts/cajun8h/cajun_lexicon.py tests/test_cajun_lexicon.py`
- `git diff --check`

`python3 -m pytest tests/test_cajun_lexicon.py tests/test_transatlantic_spelling.py -q` could not run in this local Python because `pytest` is not installed (`No module named pytest`).
