### PR TITLE
fix: enforce preprocessing audio quality gate

### DIFF
--- a/scripts/preprocess.py
+++ b/scripts/preprocess.py
@@ -122,7 +122,21 @@ def extract_segment(input_path, output_path, start, end):
     subprocess.run(cmd, capture_output=True, timeout=60)
 
 
-def check_audio_quality(wav_path, min_rms=-50, max_rms=-5):
+def _parse_volume_db(stderr, field):
+    """Return a volumedetect dB field from ffmpeg stderr."""
+    marker = f"{field}:"
+    for line in stderr.splitlines():
+        if marker not in line:
+            continue
+        value_text = line.split(marker, 1)[1].strip().split()[0]
+        try:
+            return float(value_text)
+        except ValueError:
+            return None
+    return None
+
+
+def check_audio_quality(wav_path, min_rms=-50, max_rms=-5, max_peak=-0.1):
     """Filter out silence, noise-only, or clipped segments"""
     cmd = [
         "ffprobe", "-v", "quiet",
@@ -135,18 +149,29 @@ def check_audio_quality(wav_path, min_rms=-50, max_rms=-5):
         dur = float(json.loads(result.stdout)["format"]["duration"])
         if dur < 2.0 or dur > 20.0:
             return False
-    except Exception:
+    except (KeyError, ValueError, json.JSONDecodeError):
         return False
 
-    # Check RMS level
+    # Check RMS and peak level. The previous implementation accepted any file
+    # where ffmpeg completed, which let silent or clipped segments into training.
     cmd = [
         "ffmpeg", "-i", wav_path,
-        "-af", "astats=metadata=1:reset=1",
+        "-af", "volumedetect",
         "-f", "null", "-"
     ]
     result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
-    # If ffmpeg ran ok, assume audio is valid (detailed RMS check is slow)
-    return result.returncode == 0
+    if result.returncode != 0:
+        return False
+
+    mean_volume = _parse_volume_db(result.stderr, "mean_volume")
+    max_volume = _parse_volume_db(result.stderr, "max_volume")
+    if mean_volume is None or max_volume is None:
+        return False
+    if mean_volume <= min_rms or mean_volume >= max_rms:
+        return False
+    if max_volume >= max_peak:
+        return False
+    return True
 
 
 def process_one_file(args_tuple):

--- a/tests/test_preprocess_quality.py
+++ b/tests/test_preprocess_quality.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: MIT
+from types import SimpleNamespace
+
+from scripts import preprocess
+
+
+def _patch_probe_and_volume(monkeypatch, *, duration="6.0", mean="-23.4", peak="-3.2", rc=0):
+    def fake_run(cmd, **_kwargs):
+        if cmd[0] == "ffprobe":
+            return SimpleNamespace(
+                returncode=0,
+                stdout=f'{{"format": {{"duration": "{duration}"}}}}',
+                stderr="",
+            )
+        if cmd[0] == "ffmpeg":
+            stderr = (
+                "[Parsed_volumedetect_0 @ 0x1] n_samples: 144000\n"
+                f"[Parsed_volumedetect_0 @ 0x1] mean_volume: {mean} dB\n"
+                f"[Parsed_volumedetect_0 @ 0x1] max_volume: {peak} dB\n"
+            )
+            return SimpleNamespace(returncode=rc, stdout="", stderr=stderr)
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(preprocess.subprocess, "run", fake_run)
+
+
+def test_parse_volume_db_reads_ffmpeg_volumedetect_output():
+    stderr = "[Parsed_volumedetect_0 @ 0x1] mean_volume: -23.4 dB\n"
+
+    assert preprocess._parse_volume_db(stderr, "mean_volume") == -23.4
+
+
+def test_check_audio_quality_accepts_well_leveled_segment(monkeypatch):
+    _patch_probe_and_volume(monkeypatch, mean="-23.4", peak="-3.2")
+
+    assert preprocess.check_audio_quality("sample.wav")
+
+
+def test_check_audio_quality_rejects_silent_segment(monkeypatch):
+    _patch_probe_and_volume(monkeypatch, mean="-91.0", peak="-90.2")
+
+    assert not preprocess.check_audio_quality("silent.wav")
+
+
+def test_check_audio_quality_rejects_clipped_segment(monkeypatch):
+    _patch_probe_and_volume(monkeypatch, mean="-12.0", peak="0.0")
+
+    assert not preprocess.check_audio_quality("clipped.wav")
+
+
+def test_check_audio_quality_rejects_too_hot_segment(monkeypatch):
+    _patch_probe_and_volume(monkeypatch, mean="-4.8", peak="-1.0")
+
+    assert not preprocess.check_audio_quality("too_hot.wav")
+
+
+def test_check_audio_quality_rejects_missing_volume_metrics(monkeypatch):
+    def fake_run(cmd, **_kwargs):
+        if cmd[0] == "ffprobe":
+            return SimpleNamespace(
+                returncode=0,
+                stdout='{"format": {"duration": "6.0"}}',
+                stderr="",
+            )
+        if cmd[0] == "ffmpeg":
+            return SimpleNamespace(returncode=0, stdout="", stderr="no volume here")
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(preprocess.subprocess, "run", fake_run)
+
+    assert not preprocess.check_audio_quality("unknown.wav")


### PR DESCRIPTION
## Summary

- Enforce the existing preprocessing quality gate instead of accepting every segment where ffmpeg exits successfully.
- Parse `volumedetect` `mean_volume` and `max_volume` metrics so silent/noise-only, too-hot, and clipped segments are rejected before they enter the 8GB finetune manifest.
- Add focused regression tests for valid audio, silence, clipping, hot levels, and missing ffmpeg volume metrics.

## Root Cause

`check_audio_quality()` promised to filter silence, noise-only, and clipped segments, but it returned `True` for any segment where ffmpeg completed. That let unusable audio into the Cajun 8GB finetune corpus and could make the model learn silence, clipping, or level artifacts instead of speech.

## Evidence / Validation

- `/tmp/vintage-voice-pytest/bin/python -m pytest tests/test_preprocess_quality.py -q` -> `6 passed`
- `/tmp/vintage-voice-pytest/bin/python -m pytest tests -q` -> `16 passed`
- `python3 -m py_compile scripts/preprocess.py tests/test_preprocess_quality.py` -> passed
- `git diff --check` -> passed
- Real ffmpeg sample check: generated `good.wav`, `silent.wav`, and `clipped.wav`; `check_audio_quality()` returned `True`, `False`, `False` respectively.

## Bounty

Closes #181.

This is a non-overlapping 8GB finetune pipeline quality fix: existing #181 PRs focus on loudnorm/config/resume issues, while this PR makes the documented preprocessing quality gate actually reject bad training segments.

RTC wallet address: `RTCde409a83a31e54f946144390eaeb9964a444d2e6`

No scraped audio, model weights, private data, wallet keys, seed phrases, bank, tax, or KYC information are included or touched.
