### PR TITLE
lexicon: add LSU household Cajun respellings (#178)

### DIFF
--- a/scripts/cajun8h/cajun_lexicon.py
+++ b/scripts/cajun8h/cajun_lexicon.py
@@ -196,6 +196,26 @@ LEXICON = {
     "Sophia Elya":  "Sofia Élia",
     "Elya":         "Élia",
     "Sophia":       "Sofia",
+    # ---- LSU glossary household, clothing & everyday descriptor terms ----
+    # Source: LSU Cajun French-English glossary, entries with bracketed pronunciation cues.
+    "camisole":     "camizole",        # [KAH MEE ZAWL] — nightgown; z-like s keeps the local cue
+    "canaille":     "canaï",           # [KAH NAHY] — mischievous / wily, softened local sense
+    "canaillerie":  "canaïrie",        # [KAH NAH YREE] — mischief / trickery
+    "canique":      "canique",         # [KAH NEEK] — marble (child's toy)
+    "capot":        "capo",            # [KAPO] — coat / jacket, final t silent
+    "capot ciré":   "capo ciré",       # raincoat; same final-t drop
+    "carrément":    "carrèman",        # [KAH REH MAn] — directly / abruptly
+    "carrement":    "carrèman",        # ascii-typed variant
+    "chapelet":     "chaplé",          # [SHAH PLEH] — rosary
+    "chaste-femme": "chasse-femme",    # [SHAHS FAM] — midwife; LSU gives this pronunciation variant
+    "hameçon":      "am-son",          # [AHM SOn] — fish hook, initial h silent
+    "hamecon":      "am-son",          # ascii-typed variant
+    "hélas":        "éla",             # [EHLAH] — sigh
+    "helas":        "éla",             # ascii-typed variant
+    "grands hélas": "grands éla",      # LSU phrase: faire des grands hélas
+    "grands helas": "grands éla",
+    "hibou":        "ibou",            # [EEBOO] — owl, initial h silent
+    "hormis que":   "ormi que",        # [AWRMEE KEUH] — unless
 }
 
 _lower_index = {k.lower(): v for k, v in LEXICON.items()}

--- a/tests/test_cajun_lexicon.py
+++ b/tests/test_cajun_lexicon.py
@@ -1,0 +1,37 @@
+import importlib.util
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "scripts" / "cajun8h" / "cajun_lexicon.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("cajun_lexicon", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_household_lsu_glossary_respellings():
+    lexicon = load_module()
+
+    text = "Le capot ciré, le chapelet, la canaille, et le hibou."
+
+    assert lexicon.respell(text) == "Le capo ciré, le chaplé, la canaï, et le ibou."
+
+
+def test_ascii_variants_and_phrase_respellings():
+    lexicon = load_module()
+
+    text = "Carrement, hormis que les grands helas parlent du hamecon."
+
+    assert lexicon.respell(text) == "Carrèman, ormi que les grands éla parlent du am-son."
+
+
+def test_to_js_includes_new_entries():
+    lexicon = load_module()
+
+    js = lexicon.to_js()
+
+    assert '"capot ciré": "capo ciré"' in js
+    assert '"chaste-femme": "chasse-femme"' in js


### PR DESCRIPTION
## Summary
- Adds a small append-only batch of LSU-attested household, clothing, and everyday Cajun French respellings to `scripts/cajun8h/cajun_lexicon.py`.
- Covers entries such as `camisole`, `canaille`, `capot`, `chapelet`, `chaste-femme`, `hameçon`, `hibou`, and `hormis que`.
- Adds focused tests for `respell()` and `to_js()` coverage of the new entries.

## Bounty
Closes #178

Bounty evidence: issue #178 offers 15 RTC per merged PR for regional pronunciation lexicon entries, with payout on merge to the wallet in the PR description.

RTC/EVM payout address: `0x8E8c173d17dCFf7965F076552CACBF1ad7E5e52F`

## Sources / Attestation
- LSU Cajun French-English Glossary: source basis for `camisole`, `canaille`, `canaillerie`, `canique`, `capot`, `capot ciré`, `carrément`, `chapelet`, `chaste-femme`, `hameçon`, `hélas`, `hibou`, and `hormis que`.
- The bracketed pronunciation cues in the LSU glossary are reflected in the respellings.

These are text glossary attestations only. No scraped or rights-encumbered audio is used.

## Validation
- `python3 -m pytest tests/test_cajun_lexicon.py -q` -> 3 passed
- `python3 -m pytest tests -q` -> 13 passed
- `python3 -m compileall -q scripts/cajun8h/cajun_lexicon.py tests/test_cajun_lexicon.py`
- `git diff --check`
- AST duplicate-key check -> `lexicon entries=189 duplicates=[]`

## Duplicate-work check
Checked current open #178 PRs before implementation. This batch avoids the already crowded food, place-name, surname, waterwork, weather/holiday, culinary, town-name, and broad culture batches.
