### PR TITLE
lexicon: add LSU everyday Cajun respellings (#178)

### DIFF
--- a/scripts/cajun8h/cajun_lexicon.py
+++ b/scripts/cajun8h/cajun_lexicon.py
@@ -132,6 +132,30 @@ LEXICON = {
     "cooshcoosh":   "couche-couche",
     "tracas":       "traca",           # trah-KAH — trouble / fuss / worries (silent s)
     "thraca":       "traca",
+    # ---- LSU-attested everyday verbs, games & descriptors (ear-tunable) ----
+    # Source: LSU Cajun French-English glossary, bracketed pronunciation cues.
+    "babiller":     "bah-bi-yé",       # [BAH-BEE-YEH] — to scold, usually a child
+    "badgeuler":    "bah-jeu-lé",      # [BAH JEUH LEH] — to harass / nag
+    "badjeuler":    "bah-jeu-lé",      # LSU spelling variant for badgeuler
+    "cacher-faite": "kah-shé-fête",    # [KAH SHEH FET] — hide-and-seek game
+    "cachez-fête":  "kah-shé-fête",    # LSU variant spelling
+    "cache-et-fête":"kah-shé-fête",    # LSU variant spelling
+    "brailler":     "brah-yé",         # [BRAH YEH] — to cry
+    "brin":         "bren",            # [BREn] — a little bit / small quantity
+    "fouiller":     "fou-yé",          # [FOOYEH] — to dig / rummage around
+    "fréquenter":   "fré-kan-té",      # [FREH KAnTEH] — to socialize / visit regularly
+    "frequenter":   "fré-kan-té",      # ascii-typed variant
+    "gaspiller":    "gah-spi-yé",      # [GAH SPEE YEH] — to waste
+    "grouiller":    "grou-yé",        # [GROOYEH] — to move
+    "fatras":       "fah-trah",        # [FAH TRAH] — trash / no-account person
+    "pistache":     "pi-stahsh",       # [PEE STAH SH] — peanut
+    "plaquemine":   "plahk-mine",      # [PLAHKMEEN] — persimmon; lowercase lexicon sense
+    "poulailler":   "pou-la-yé",       # [POO LAH YEH] — chicken coop
+    "quereller":    "kré-lé",          # [KRE LEH] — to argue / scold
+    "espeler":      "esplé",           # [ESPLEH] — to spell
+    "dételer":      "dé-tlé",          # [DEH TLEH] — to unharness
+    "deteler":      "dé-tlé",          # ascii-typed variant
+    "avalasse":     "ah-vah-lahs",     # [AH VAH LAHS] — downpour
     # ---- St. Landry / prairie-Cajun colloquial (deep-research 2026-06-16) ----
     "asteur":       "asteur",          # ah-STUR — "now" (from à cette heure)
     "astheure":     "asteur",


### PR DESCRIPTION
## Summary

Adds a separate LSU-attested batch of everyday Cajun French verbs, game terms, and descriptors to `scripts/cajun8h/cajun_lexicon.py`.

This batch avoids the open food, place-name, surname, waterwork, household/clothing, religion/weather, and music/folklore batches already in flight for #178.

## Entries Added

- `babiller`, `badgeuler` / `badjeuler`
- `cacher-faite` plus LSU spelling variants
- `brailler`, `brin`, `fouiller`
- `fréquenter` / `frequenter`
- `gaspiller`, `grouiller`, `fatras`
- `pistache`, `plaquemine`, `poulailler`
- `quereller`, `espeler`, `dételer` / `deteler`
- `avalasse`

Source: LSU Cajun French-English glossary, using entries with bracketed pronunciation cues.

## Validation

- `python -m py_compile scripts/cajun8h/cajun_lexicon.py`
- `python scripts/cajun8h/cajun_lexicon.py "Les enfants vont jouer cacher-faite et brailler un brin."`
  - Output: `Les enfants vont jouer kah-shé-fête et brah-yé un bren.`
- `python scripts/cajun8h/cajun_lexicon.py --js`

## Bounty

Closes #178

RTC wallet: `RTC60feff9b3f4c8784e505422014ef5d8a4e305b16`
