### PR TITLE
preprocess: reconcile security + two-pass loudnorm + RMS/peak gate (#198/#194/#197)

### DIFF
--- a/scripts/preprocess.py
+++ b/scripts/preprocess.py
@@ -79,6 +79,56 @@ def assert_safe_audio_input(path):
             raise ValueError(f"refusing non-audio/playlist payload: {path}")
 
 
+def _parse_loudnorm_json(stderr):
+    """Extract the loudnorm measurement dict from ffmpeg's stderr.
+
+    With ``print_format=json`` ffmpeg emits a *multi-line* JSON object at the
+    END of stderr, e.g.::
+
+        [Parsed_loudnorm_0 @ 0x...]
+        {
+            "input_i" : "-27.61",
+            "input_tp" : "-9.30",
+            "input_lra" : "5.40",
+            "input_thresh" : "-37.79",
+            ...
+        }
+
+    A line-by-line ``json.loads`` never sees a complete object, so the whole
+    two-pass feature silently degraded to single-pass. Here we locate the LAST
+    balanced ``{ ... }`` block in stderr and parse it. Returns a dict with the
+    ``input_*`` keys on success, or ``{}`` on any parse failure (caller falls
+    back to single-pass).
+    """
+    if not stderr:
+        return {}
+    # ffmpeg's JSON block is the last top-level object in stderr. Find the last
+    # '{' and walk forward tracking brace depth to its matching '}', which is
+    # robust even if other braces appear earlier in the log.
+    start = stderr.rfind('{')
+    while start != -1:
+        depth = 0
+        for idx in range(start, len(stderr)):
+            ch = stderr[idx]
+            if ch == '{':
+                depth += 1
+            elif ch == '}':
+                depth -= 1
+                if depth == 0:
+                    block = stderr[start:idx + 1]
+                    try:
+                        candidate = json.loads(block)
+                    except json.JSONDecodeError:
+                        break  # malformed block; try an earlier '{'
+                    if isinstance(candidate, dict) and 'input_i' in candidate:
+                        return candidate
+                    break  # parsed but not the loudnorm object; look earlier
+        # Either we broke out (malformed / wrong object) or never closed the
+        # brace — search for an earlier '{' before this one.
+        start = stderr.rfind('{', 0, start)
+    return {}
+
+
 def _ffmpeg_to_temp(output_path, cmd, timeout):
     """Run an ffmpeg command, writing the result atomically to output_path.
 
@@ -135,20 +185,16 @@ def convert_to_wav(input_path, output_path, sample_rate=24000):
     except subprocess.SubprocessError:
         measure = None
 
-    # Parse the JSON measurement from stderr (ffmpeg prints it after progress).
-    measured = {}
-    if measure is not None:
-        for line in measure.stderr.strip().split('\n'):
-            try:
-                candidate = json.loads(line)
-            except json.JSONDecodeError:
-                continue
-            if isinstance(candidate, dict) and 'input_i' in candidate:
-                measured = candidate
-                break
+    # Parse the JSON measurement from stderr. ffmpeg emits a *multi-line* JSON
+    # object at the end of stderr, so we extract the trailing balanced block
+    # rather than scanning line-by-line (which never sees a complete object).
+    measured = _parse_loudnorm_json(measure.stderr) if measure is not None else {}
 
     # ── Pass 2: Apply with measured values ──
-    if measured:
+    # Require every field pass-2 consumes; a partial measurement is treated as a
+    # failure so we fall back to single-pass instead of emitting a broken filter.
+    required = ("input_i", "input_tp", "input_lra", "input_thresh")
+    if measured and all(k in measured for k in required):
         # linear=true: apply pure gain — no dynamic compression. Preserves the
         # original dynamic range while hitting the exact target loudness.
         loudnorm_filter = (
@@ -159,6 +205,10 @@ def convert_to_wav(input_path, output_path, sample_rate=24000):
             f"measured_thresh={measured['input_thresh']}:"
             f"linear=true:print_format=summary"
         )
+        # ffmpeg also reports the DC/normalization offset; pass it through when
+        # present so pass-2 reproduces pass-1's gain decision exactly.
+        if "target_offset" in measured:
+            loudnorm_filter += f":offset={measured['target_offset']}"
     else:
         # Fallback: measurement failed (e.g. very short audio). Best-effort
         # single-pass — rare, but better than dropping the file.
@@ -311,7 +361,13 @@ def check_audio_quality(wav_path, min_rms=-50, max_rms=-5, max_peak=-0.1):
         "-af", "volumedetect",
         "-f", "null", "-"
     ]
-    result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    # A volumedetect timeout or ffmpeg error must reject only THIS segment, not
+    # propagate out of the worker and drop the entire source file. Treat any
+    # subprocess failure as "fails quality".
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    except (subprocess.SubprocessError, OSError):
+        return False
     if result.returncode != 0:
         return False
 
@@ -344,6 +400,16 @@ def process_one_file(args_tuple):
             # Rejected non-audio / playlist payload — skip silently.
             return []
         if not ok:
+            return []
+    else:
+        # Resume / pre-populated wav_dir path: the WAV already exists, so
+        # convert_to_wav (which sniffs the input) is skipped. Sniff the existing
+        # WAV here too — otherwise a .wav whose *content* is a playlist/markup
+        # payload would flow straight into ffmpeg via split_on_silence(),
+        # re-opening the SSRF/local-read hole (CWE-918) on the resume path.
+        try:
+            assert_safe_audio_input(wav_path)
+        except ValueError:
             return []
 
     # Split on silence

--- a/scripts/preprocess.py
+++ b/scripts/preprocess.py
@@ -5,41 +5,186 @@ VintageVoice — Audio Preprocessing Pipeline
 Converts raw archive.org audio into training-ready segments.
 
 Pipeline:
-1. Convert all audio to 24kHz mono WAV (F5-TTS native rate)
+1. Convert all audio to 24kHz mono WAV (F5-TTS native rate) with two-pass loudnorm
 2. Split into 5-15 second segments on silence boundaries
-3. Filter out music-only, noise-only, and too-quiet segments
+3. Filter out music-only, noise-only, and too-quiet/clipped segments (RMS+peak gate)
 4. Normalize loudness to -23 LUFS
 5. Generate manifest CSV for training
+
+Security hardening (CWE-918 SSRF, CWE-59/CWE-367 symlink TOCTOU, CWE-1236 CSV
+injection): all ffmpeg/ffprobe invocations are restricted to local file access,
+inputs are content-sniffed before processing, outputs are written atomically, and
+manifests are emitted with csv.writer.
 """
 import argparse
 import os
 import subprocess
 import json
+import csv
+import re
+import hashlib
+import tempfile
 from pathlib import Path
 from concurrent.futures import ProcessPoolExecutor, as_completed
 
 
+# --- Security hardening ------------------------------------------------------
+# Restrict FFmpeg/ffprobe to local file access only. Without this, a file whose
+# *content* is an HLS/concat playlist (regardless of its extension) can make
+# FFmpeg follow http/file URLs embedded in it, enabling SSRF and arbitrary file
+# reads (CWE-918).
+FFMPEG_PROTOCOLS = "file,pipe"
+
+# Headers of playlist / markup payloads that must never be fed to FFmpeg even if
+# they carry an audio extension. Real audio containers start with ID3/RIFF/OggS/
+# fLaC/ftyp — never with these signatures.
+_DANGEROUS_HEADERS = (b"#EXTM3U", b"#EXT-X", b"ffconcat", b"<?xml", b"<")
+
+# Characters allowed in derived output filenames; everything else collapses to
+# "_" so a crafted source name cannot inject CSV rows or path separators
+# (CWE-1236 / CWE-507).
+_SAFE_STEM_RE = re.compile(r"[^A-Za-z0-9._-]+")
+
+
+def _safe_stem(name):
+    """Sanitize a filename stem for safe use in output paths and the manifest.
+
+    Distinct inputs MUST map to distinct outputs. Naive sanitization collapses
+    e.g. "a:b", "a|b" and "a/b" all to "a_b", so unrelated files would overwrite
+    each other. To guarantee uniqueness, when sanitization actually changes the
+    stem we append a short hash of the *original* name. Names that are already
+    safe pass through unchanged (preserves readable output filenames and keeps
+    behaviour stable for the common case).
+    """
+    sanitized = _SAFE_STEM_RE.sub("_", name).strip("._")
+    if sanitized == name:
+        # Already filesystem/CSV-safe — leave it untouched.
+        return sanitized or "segment"
+    base = sanitized or "segment"
+    # Short, stable suffix derived from the original (pre-sanitization) name so
+    # that two different originals can never collide on the same output stem.
+    digest = hashlib.sha1(name.encode("utf-8", "surrogatepass")).hexdigest()[:8]
+    return f"{base}_{digest}"
+
+
+def assert_safe_audio_input(path):
+    """Reject inputs whose content is a playlist/markup disguised as audio."""
+    try:
+        with open(path, "rb") as fh:
+            head = fh.read(64).lstrip()
+    except OSError:
+        raise ValueError(f"cannot read input: {path}")
+    for sig in _DANGEROUS_HEADERS:
+        if head.startswith(sig):
+            raise ValueError(f"refusing non-audio/playlist payload: {path}")
+
+
+def _ffmpeg_to_temp(output_path, cmd, timeout):
+    """Run an ffmpeg command, writing the result atomically to output_path.
+
+    FFmpeg writes to a freshly created temp file in the destination directory;
+    on success it is os.replace()'d onto output_path. This defeats the symlink /
+    TOCTOU arbitrary-write attack (CWE-367, CWE-59): even if output_path is a
+    planted symlink, os.replace overwrites the link itself, never its target.
+    The temp name carries no controlled extension, so callers must force the
+    output format explicitly (e.g. "-f", "wav").
+
+    Returns True on success, False on any failure (non-zero exit, empty output,
+    timeout, etc.). Callers MUST check the return value before using output_path.
+    """
+    out_dir = os.path.dirname(output_path) or "."
+    fd, tmp_path = tempfile.mkstemp(suffix=".tmp", dir=out_dir)
+    os.close(fd)
+    try:
+        result = subprocess.run(cmd + [tmp_path], capture_output=True, timeout=timeout)
+        if result.returncode != 0 or not os.path.getsize(tmp_path):
+            os.unlink(tmp_path)
+            return False
+        os.replace(tmp_path, output_path)
+        return True
+    except Exception:
+        if os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+        return False
+
+
 def convert_to_wav(input_path, output_path, sample_rate=24000):
-    """Convert any audio to 24kHz mono WAV"""
+    """Convert any audio to 24kHz mono WAV with proper two-pass loudnorm.
+
+    Two-pass loudnorm is essential for TTS training data:
+    - Pass 1 measures the true integrated loudness of the full file.
+    - Pass 2 applies a linear gain to hit exactly -23 LUFS, preventing the model
+      from learning volume variations instead of speech patterns.
+    - If measurement fails (malformed/short audio), falls back to single-pass.
+
+    Security: the input is content-sniffed first, ffmpeg is locked to local
+    protocols, and the result is written atomically (defeats symlink TOCTOU).
+    """
+    assert_safe_audio_input(input_path)
+
+    # ── Pass 1: Measure true integrated loudness ──
+    measure_cmd = [
+        "ffmpeg", "-y", "-protocol_whitelist", FFMPEG_PROTOCOLS,
+        "-i", input_path,
+        "-ar", str(sample_rate), "-ac", "1",
+        "-af", "loudnorm=I=-23:TP=-1.5:LRA=11:print_format=json",
+        "-f", "null", "-"
+    ]
+    try:
+        measure = subprocess.run(measure_cmd, capture_output=True, text=True, timeout=300)
+    except subprocess.SubprocessError:
+        measure = None
+
+    # Parse the JSON measurement from stderr (ffmpeg prints it after progress).
+    measured = {}
+    if measure is not None:
+        for line in measure.stderr.strip().split('\n'):
+            try:
+                candidate = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(candidate, dict) and 'input_i' in candidate:
+                measured = candidate
+                break
+
+    # ── Pass 2: Apply with measured values ──
+    if measured:
+        # linear=true: apply pure gain — no dynamic compression. Preserves the
+        # original dynamic range while hitting the exact target loudness.
+        loudnorm_filter = (
+            f"loudnorm=I=-23:TP=-1.5:LRA=11:"
+            f"measured_I={measured['input_i']}:"
+            f"measured_TP={measured['input_tp']}:"
+            f"measured_LRA={measured['input_lra']}:"
+            f"measured_thresh={measured['input_thresh']}:"
+            f"linear=true:print_format=summary"
+        )
+    else:
+        # Fallback: measurement failed (e.g. very short audio). Best-effort
+        # single-pass — rare, but better than dropping the file.
+        print(f"  [WARN] loudnorm measurement failed for {input_path}, "
+              f"falling back to single-pass", flush=True)
+        loudnorm_filter = "loudnorm=I=-23:TP=-1.5:LRA=11"
+
     cmd = [
-        "ffmpeg", "-y", "-i", input_path,
+        "ffmpeg", "-y", "-protocol_whitelist", FFMPEG_PROTOCOLS,
+        "-i", input_path,
         "-ar", str(sample_rate), "-ac", "1",
         "-c:a", "pcm_s16le",
-        "-af", "loudnorm=I=-23:TP=-1.5:LRA=11",
-        output_path
+        "-af", loudnorm_filter,
+        "-f", "wav",
     ]
-    result = subprocess.run(cmd, capture_output=True, timeout=300)
-    return result.returncode == 0
+    return _ffmpeg_to_temp(output_path, cmd, timeout=300)
 
 
 def split_on_silence(wav_path, output_dir, min_dur=3.0, max_dur=15.0, silence_thresh=-40):
     """Split audio on silence boundaries into segments"""
     os.makedirs(output_dir, exist_ok=True)
-    stem = Path(wav_path).stem
+    stem = _safe_stem(Path(wav_path).stem)
 
     # Use ffmpeg silencedetect to find split points
     cmd = [
-        "ffmpeg", "-i", wav_path,
+        "ffmpeg", "-protocol_whitelist", FFMPEG_PROTOCOLS, "-i", wav_path,
         "-af", f"silencedetect=noise={silence_thresh}dB:d=0.5",
         "-f", "null", "-"
     ]
@@ -65,8 +210,8 @@ def split_on_silence(wav_path, output_dir, min_dur=3.0, max_dur=15.0, silence_th
 
     # Get total duration
     probe_cmd = [
-        "ffprobe", "-v", "quiet", "-show_entries",
-        "format=duration", "-of", "json", wav_path
+        "ffprobe", "-v", "quiet", "-protocol_whitelist", FFMPEG_PROTOCOLS,
+        "-show_entries", "format=duration", "-of", "json", wav_path
     ]
     probe = subprocess.run(probe_cmd, capture_output=True, text=True)
     try:
@@ -96,36 +241,57 @@ def split_on_silence(wav_path, output_dir, min_dur=3.0, max_dur=15.0, silence_th
         while duration > max_dur:
             seg_end = start + max_dur
             seg_path = os.path.join(output_dir, f"{stem}_seg{seg_idx:04d}.wav")
-            extract_segment(wav_path, seg_path, start, seg_end)
-            segments.append({"path": seg_path, "start": start, "end": seg_end, "duration": max_dur})
-            seg_idx += 1
+            # Only record the segment if extraction actually produced a file.
+            if extract_segment(wav_path, seg_path, start, seg_end):
+                segments.append({"path": seg_path, "start": start, "end": seg_end, "duration": max_dur})
+                seg_idx += 1
             start = seg_end
             duration = end - start
 
         if duration >= min_dur:
             seg_path = os.path.join(output_dir, f"{stem}_seg{seg_idx:04d}.wav")
-            extract_segment(wav_path, seg_path, start, end)
-            segments.append({"path": seg_path, "start": start, "end": end, "duration": duration})
-            seg_idx += 1
+            if extract_segment(wav_path, seg_path, start, end):
+                segments.append({"path": seg_path, "start": start, "end": end, "duration": duration})
+                seg_idx += 1
 
     return segments
 
 
 def extract_segment(input_path, output_path, start, end):
-    """Extract a time segment from audio"""
+    """Extract a time segment from audio.
+
+    Returns True only if ffmpeg succeeded and a non-empty output was written.
+    Callers MUST honour the return value — a failed segment must not flow into
+    quality checks or the manifest.
+    """
     cmd = [
-        "ffmpeg", "-y", "-i", input_path,
+        "ffmpeg", "-y", "-protocol_whitelist", FFMPEG_PROTOCOLS,
+        "-i", input_path,
         "-ss", str(start), "-to", str(end),
         "-c:a", "pcm_s16le",
-        output_path
+        "-f", "wav",
     ]
-    subprocess.run(cmd, capture_output=True, timeout=60)
+    return _ffmpeg_to_temp(output_path, cmd, timeout=60)
 
 
-def check_audio_quality(wav_path, min_rms=-50, max_rms=-5):
-    """Filter out silence, noise-only, or clipped segments"""
+def _parse_volume_db(stderr, field):
+    """Return a volumedetect dB field from ffmpeg stderr."""
+    marker = f"{field}:"
+    for line in stderr.splitlines():
+        if marker not in line:
+            continue
+        value_text = line.split(marker, 1)[1].strip().split()[0]
+        try:
+            return float(value_text)
+        except ValueError:
+            return None
+    return None
+
+
+def check_audio_quality(wav_path, min_rms=-50, max_rms=-5, max_peak=-0.1):
+    """Filter out silence, noise-only, or clipped segments via a real RMS/peak gate."""
     cmd = [
-        "ffprobe", "-v", "quiet",
+        "ffprobe", "-v", "quiet", "-protocol_whitelist", FFMPEG_PROTOCOLS,
         "-show_entries", "stream=codec_type",
         "-show_entries", "format=duration",
         "-of", "json", wav_path
@@ -135,29 +301,48 @@ def check_audio_quality(wav_path, min_rms=-50, max_rms=-5):
         dur = float(json.loads(result.stdout)["format"]["duration"])
         if dur < 2.0 or dur > 20.0:
             return False
-    except Exception:
+    except (KeyError, ValueError, json.JSONDecodeError):
         return False
 
-    # Check RMS level
+    # Check RMS and peak level. The previous implementation accepted any file
+    # where ffmpeg completed, which let silent or clipped segments into training.
     cmd = [
-        "ffmpeg", "-i", wav_path,
-        "-af", "astats=metadata=1:reset=1",
+        "ffmpeg", "-protocol_whitelist", FFMPEG_PROTOCOLS, "-i", wav_path,
+        "-af", "volumedetect",
         "-f", "null", "-"
     ]
     result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
-    # If ffmpeg ran ok, assume audio is valid (detailed RMS check is slow)
-    return result.returncode == 0
+    if result.returncode != 0:
+        return False
+
+    mean_volume = _parse_volume_db(result.stderr, "mean_volume")
+    max_volume = _parse_volume_db(result.stderr, "max_volume")
+    if mean_volume is None or max_volume is None:
+        return False
+    if mean_volume <= min_rms or mean_volume >= max_rms:
+        return False
+    if max_volume >= max_peak:
+        return False
+    return True
 
 
 def process_one_file(args_tuple):
     """Process a single audio file — convert, split, filter"""
     input_path, wav_dir, seg_dir = args_tuple
-    stem = Path(input_path).stem
+    stem = _safe_stem(Path(input_path).stem)
 
     # Convert to WAV
     wav_path = os.path.join(wav_dir, f"{stem}.wav")
+    # Refuse to read or overwrite through a symlink planted at the output path
+    # (CWE-59): otherwise ffmpeg would follow it to an arbitrary target.
+    if os.path.islink(wav_path):
+        return []
     if not os.path.exists(wav_path):
-        ok = convert_to_wav(input_path, wav_path)
+        try:
+            ok = convert_to_wav(input_path, wav_path)
+        except ValueError:
+            # Rejected non-audio / playlist payload — skip silently.
+            return []
         if not ok:
             return []
 
@@ -170,7 +355,10 @@ def process_one_file(args_tuple):
         if check_audio_quality(seg["path"]):
             good_segments.append(seg)
         else:
-            os.unlink(seg["path"])
+            try:
+                os.unlink(seg["path"])
+            except OSError:
+                pass
 
     return good_segments
 
@@ -213,12 +401,16 @@ def main():
             except Exception as e:
                 print(f"  [{i+1}/{len(files)}] ERROR {src}: {e}")
 
-    # Write manifest
+    # Write manifest. Use csv.writer (not raw string formatting) so any field
+    # containing a pipe, quote or newline is properly quoted — this prevents
+    # manifest row injection / ML data poisoning (CWE-1236) while staying
+    # compatible with the downstream csv.DictReader(delimiter="|") consumers.
     manifest_path = os.path.join(args.output, "manifest.csv")
-    with open(manifest_path, "w") as f:
-        f.write("path|duration|source\n")
+    with open(manifest_path, "w", newline="") as f:
+        writer = csv.writer(f, delimiter="|", quoting=csv.QUOTE_MINIMAL)
+        writer.writerow(["path", "duration", "source"])
         for seg in all_segments:
-            f.write(f"{seg['path']}|{seg['duration']:.2f}|{Path(seg['path']).stem}\n")
+            writer.writerow([seg["path"], f"{seg['duration']:.2f}", Path(seg["path"]).stem])
 
     print(f"\nDone! {len(all_segments)} segments from {len(files)} files")
     print(f"Manifest: {manifest_path}")

--- a/scripts/run_cajun_pipeline.sh
+++ b/scripts/run_cajun_pipeline.sh
@@ -103,13 +103,23 @@ stage "D: done — manifests: $(ls $TRANSCRIBED/train_*.csv 2>/dev/null | xargs 
 # ---------- Stage E: build F5 dataset (French, QC-clean) ----------
 # Resume guard (matches Stage B pattern): on a re-run after a later-stage crash,
 # skip the expensive CSV + Arrow rebuild — BUT only if the existing CSV is
-# actually complete. A crashed Stage E could leave a truncated/partial CSV on
-# disk; skipping on mere existence would feed garbage into training. We therefore
-# (a) write the CSV atomically (temp file + os.replace, so it only appears once
-# fully written) and (b) verify completeness (header present + >= the required
-# 100 sample rows) before skipping.
+# actually complete AND up-to-date. A crashed Stage E could leave a
+# truncated/partial CSV on disk; skipping on mere existence would feed garbage
+# into training. We therefore (a) write the CSV atomically (temp file +
+# os.replace, so it only appears once fully written), (b) verify completeness
+# (header present + >= the required 100 sample rows), and (c) require the CSV to
+# be NEWER than every transcribed input it derives from — otherwise a re-run
+# after Stage D produced fresh/changed transcriptions would silently train on a
+# stale CSV.
 stage_e_csv_complete() {
     [ -s "$F5_CSV" ] || return 1
+    # Staleness check: if any transcribed *.json is newer than the CSV, the
+    # transcriptions changed since the CSV was built — force a rebuild. `find
+    # -newer` prints the offending file(s); a non-empty result means stale.
+    if [ -d "$TRANSCRIBED" ] && \
+       [ -n "$(find "$TRANSCRIBED" -maxdepth 1 -name '*.json' -newer "$F5_CSV" -print -quit 2>/dev/null)" ]; then
+        return 1
+    fi
     $VENV/python - "$F5_CSV" <<'PYEOF'
 import sys
 path = sys.argv[1]

--- a/scripts/run_cajun_pipeline.sh
+++ b/scripts/run_cajun_pipeline.sh
@@ -101,9 +101,36 @@ $VENV/python $BASE/scripts/transcribe_watchdog.py \
 stage "D: done — manifests: $(ls $TRANSCRIBED/train_*.csv 2>/dev/null | xargs -n1 basename | tr '\n' ' ' || true)"
 
 # ---------- Stage E: build F5 dataset (French, QC-clean) ----------
-stage "E: building F5 CSV from clean French segments"
-$VENV/python - "$TRANSCRIBED" "$F5_CSV" <<'EOF'
-import glob, json, os, sys, unicodedata
+# Resume guard (matches Stage B pattern): on a re-run after a later-stage crash,
+# skip the expensive CSV + Arrow rebuild — BUT only if the existing CSV is
+# actually complete. A crashed Stage E could leave a truncated/partial CSV on
+# disk; skipping on mere existence would feed garbage into training. We therefore
+# (a) write the CSV atomically (temp file + os.replace, so it only appears once
+# fully written) and (b) verify completeness (header present + >= the required
+# 100 sample rows) before skipping.
+stage_e_csv_complete() {
+    [ -s "$F5_CSV" ] || return 1
+    $VENV/python - "$F5_CSV" <<'PYEOF'
+import sys
+path = sys.argv[1]
+try:
+    with open(path, encoding="utf-8") as fh:
+        lines = [ln for ln in (l.rstrip("\n") for l in fh) if ln]
+except OSError:
+    sys.exit(1)
+# Must have the header plus at least the 100 sample rows Stage E enforces.
+if not lines or lines[0] != "audio_file|text":
+    sys.exit(1)
+sys.exit(0 if (len(lines) - 1) >= 100 else 1)
+PYEOF
+}
+
+if stage_e_csv_complete; then
+    stage "E: skip (complete F5 CSV exists)"
+else
+    stage "E: building F5 CSV from clean French segments"
+    $VENV/python - "$TRANSCRIBED" "$F5_CSV" <<'EOF'
+import glob, json, os, sys, unicodedata, tempfile
 trans_dir, out_csv = sys.argv[1], sys.argv[2]
 vocab = set(l.rstrip("\n") for l in open("/home/scott/vintage-voice/models/OpenF5-TTS-Base/vocab.txt"))
 rows, dropped_chars, hours = [], set(), 0.0
@@ -120,15 +147,28 @@ for jf in sorted(glob.glob(os.path.join(trans_dir, "*.json"))):
     if len(text) > 5 and os.path.exists(d["audio_path"]):
         rows.append(f'{d["audio_path"]}|{text}')
         hours += d.get("duration", 0) / 3600
-with open(out_csv, "w") as f:
-    f.write("audio_file|text\n" + "\n".join(rows) + "\n")
 print(f"French clean samples: {len(rows)}  ({hours:.2f}h)")
 if dropped_chars:
     print(f"chars stripped (not in vocab): {sorted(dropped_chars)}")
 if len(rows) < 100:
+    # Abort BEFORE writing — never leave a partial/undersized CSV that a later
+    # resume could mistake for valid output.
     print("FATAL: under 100 clean French samples — not enough to fine-tune")
     sys.exit(3)
+# Atomic write: build the full file in a temp path, then os.replace() it into
+# place so the CSV at out_csv is only ever the complete article.
+out_dir = os.path.dirname(out_csv) or "."
+fd, tmp = tempfile.mkstemp(suffix=".tmp", dir=out_dir)
+try:
+    with os.fdopen(fd, "w") as f:
+        f.write("audio_file|text\n" + "\n".join(rows) + "\n")
+    os.replace(tmp, out_csv)
+except Exception:
+    if os.path.exists(tmp):
+        os.unlink(tmp)
+    raise
 EOF
+fi
 
 stage "E: preparing Arrow dataset"
 # Pre-seed pretrained vocab where prepare_csv_wavs looks for it in finetune mode
@@ -147,9 +187,10 @@ cd $BASE
 # fp32 training of 337M params = ~6.7GB in weights/grads/Adam/EMA alone -> OOM on 8GB.
 # fp16 autocast (env honored: Trainer passes no mixed_precision) + bnb 8-bit AdamW
 # cuts optimizer state ~2GB and halves activation memory.
+# FIX: removed dead PYTORCH_ALLOC_CONF (typo — wrong variable name, had no
+# effect). Only PYTORCH_CUDA_ALLOC_CONF is honored for expandable_segments.
 WANDB_MODE=offline \
 ACCELERATE_MIXED_PRECISION=fp16 \
-PYTORCH_ALLOC_CONF=expandable_segments:True \
 PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True \
 CUDA_VISIBLE_DEVICES=0 $VENV/python -m f5_tts.train.finetune_cli \
     --bnb_optimizer \

--- a/tests/test_preprocess_loudnorm.py
+++ b/tests/test_preprocess_loudnorm.py
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: MIT
+"""Tests for the two-pass loudnorm JSON parsing + resume-path hardening."""
+from types import SimpleNamespace
+
+import pytest
+
+from scripts import preprocess
+
+
+# A realistic ffmpeg stderr: normal banner/log lines, then the multi-line JSON
+# block loudnorm prints at the very end with print_format=json.
+REALISTIC_STDERR = """ffmpeg version 6.1.1 Copyright (c) 2000-2023 the FFmpeg developers
+  built with gcc 13 (GCC)
+Input #0, mp3, from 'in.mp3':
+  Duration: 00:03:21.50, start: 0.025057, bitrate: 128 kb/s
+Stream mapping:
+  Stream #0:0 -> #0:0 (mp3 (mp3float) -> pcm_s16le (native))
+[Parsed_loudnorm_0 @ 0x55d1f0]
+{
+	"input_i" : "-27.61",
+	"input_tp" : "-9.30",
+	"input_lra" : "5.40",
+	"input_thresh" : "-37.79",
+	"output_i" : "-23.00",
+	"output_tp" : "-1.50",
+	"output_lra" : "5.30",
+	"output_thresh" : "-33.18",
+	"normalization_type" : "dynamic",
+	"target_offset" : "0.21"
+}
+"""
+
+
+def test_parse_loudnorm_json_extracts_trailing_block():
+    measured = preprocess._parse_loudnorm_json(REALISTIC_STDERR)
+    assert measured["input_i"] == "-27.61"
+    assert measured["input_tp"] == "-9.30"
+    assert measured["input_lra"] == "5.40"
+    assert measured["input_thresh"] == "-37.79"
+    assert measured["target_offset"] == "0.21"
+
+
+def test_parse_loudnorm_json_returns_empty_on_garbage():
+    assert preprocess._parse_loudnorm_json("no json here at all") == {}
+    assert preprocess._parse_loudnorm_json("") == {}
+    # A truncated/partial block (crashed pass 1) must not parse.
+    assert preprocess._parse_loudnorm_json('[loudnorm]\n{\n\t"input_i" : "-27') == {}
+
+
+def test_parse_loudnorm_json_ignores_unrelated_json_object():
+    # An earlier non-loudnorm JSON object must not be mistaken for the result.
+    stderr = '{"foo": 1}\n[Parsed_loudnorm_0]\n{\n  "input_i": "-20.0",\n  "input_tp": "-3.0",\n  "input_lra": "4.0",\n  "input_thresh": "-30.0"\n}\n'
+    measured = preprocess._parse_loudnorm_json(stderr)
+    assert measured["input_i"] == "-20.0"
+    assert "foo" not in measured
+
+
+def test_convert_to_wav_runs_two_pass_when_measured(monkeypatch):
+    """With a valid measurement, pass 2 must use the measured_* values."""
+    captured = {}
+
+    def fake_run(cmd, **_kwargs):
+        # First call = measurement pass (-f null), returns JSON in stderr.
+        if "null" in cmd:
+            return SimpleNamespace(returncode=0, stdout="", stderr=REALISTIC_STDERR)
+        raise AssertionError(f"unexpected measurement command: {cmd}")
+
+    def fake_to_temp(output_path, cmd, timeout):
+        # Capture the pass-2 ffmpeg command (the one writing the WAV).
+        captured["cmd"] = cmd
+        return True
+
+    monkeypatch.setattr(preprocess, "assert_safe_audio_input", lambda p: None)
+    monkeypatch.setattr(preprocess.subprocess, "run", fake_run)
+    monkeypatch.setattr(preprocess, "_ffmpeg_to_temp", fake_to_temp)
+
+    assert preprocess.convert_to_wav("in.mp3", "out.wav") is True
+
+    filt = captured["cmd"][captured["cmd"].index("-af") + 1]
+    assert "measured_I=-27.61" in filt
+    assert "measured_TP=-9.30" in filt
+    assert "measured_LRA=5.40" in filt
+    assert "measured_thresh=-37.79" in filt
+    assert "linear=true" in filt
+    assert "offset=0.21" in filt
+
+
+def test_convert_to_wav_falls_back_on_unparseable_measurement(monkeypatch):
+    """Genuine parse failure must drop to single-pass loudnorm, not crash."""
+    captured = {}
+
+    def fake_run(cmd, **_kwargs):
+        return SimpleNamespace(returncode=0, stdout="", stderr="no json here")
+
+    def fake_to_temp(output_path, cmd, timeout):
+        captured["cmd"] = cmd
+        return True
+
+    monkeypatch.setattr(preprocess, "assert_safe_audio_input", lambda p: None)
+    monkeypatch.setattr(preprocess.subprocess, "run", fake_run)
+    monkeypatch.setattr(preprocess, "_ffmpeg_to_temp", fake_to_temp)
+
+    assert preprocess.convert_to_wav("in.mp3", "out.wav") is True
+    filt = captured["cmd"][captured["cmd"].index("-af") + 1]
+    assert filt == "loudnorm=I=-23:TP=-1.5:LRA=11"
+    assert "measured_" not in filt
+
+
+def test_existing_wav_is_sniffed_on_resume(monkeypatch, tmp_path):
+    """An existing .wav whose content is a playlist must be rejected (CWE-918)."""
+    wav_dir = tmp_path / "wav"
+    seg_dir = tmp_path / "seg"
+    wav_dir.mkdir()
+    seg_dir.mkdir()
+    # Pre-populate wav_dir with a malicious "wav" that is actually an HLS playlist.
+    poisoned = wav_dir / "track.wav"
+    poisoned.write_bytes(b"#EXTM3U\nhttp://169.254.169.254/latest/meta-data\n")
+
+    # split_on_silence must NEVER be reached for the poisoned file.
+    def boom(*_a, **_k):
+        raise AssertionError("split_on_silence reached a non-audio payload")
+
+    monkeypatch.setattr(preprocess, "split_on_silence", boom)
+
+    result = preprocess.process_one_file((str(tmp_path / "track.mp3"), str(wav_dir), str(seg_dir)))
+    assert result == []
+
+
+def test_check_audio_quality_rejects_segment_on_volumedetect_timeout(monkeypatch):
+    """A volumedetect timeout must reject the segment, not propagate."""
+    def fake_run(cmd, **_kwargs):
+        if cmd[0] == "ffprobe":
+            return SimpleNamespace(
+                returncode=0,
+                stdout='{"format": {"duration": "6.0"}}',
+                stderr="",
+            )
+        if cmd[0] == "ffmpeg":
+            raise preprocess.subprocess.TimeoutExpired(cmd, 30)
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(preprocess.subprocess, "run", fake_run)
+
+    # Must return False (segment rejected), NOT raise out of the worker.
+    assert preprocess.check_audio_quality("slow.wav") is False

--- a/tests/test_preprocess_quality.py
+++ b/tests/test_preprocess_quality.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: MIT
+from types import SimpleNamespace
+
+from scripts import preprocess
+
+
+def _patch_probe_and_volume(monkeypatch, *, duration="6.0", mean="-23.4", peak="-3.2", rc=0):
+    def fake_run(cmd, **_kwargs):
+        if cmd[0] == "ffprobe":
+            return SimpleNamespace(
+                returncode=0,
+                stdout=f'{{"format": {{"duration": "{duration}"}}}}',
+                stderr="",
+            )
+        if cmd[0] == "ffmpeg":
+            stderr = (
+                "[Parsed_volumedetect_0 @ 0x1] n_samples: 144000\n"
+                f"[Parsed_volumedetect_0 @ 0x1] mean_volume: {mean} dB\n"
+                f"[Parsed_volumedetect_0 @ 0x1] max_volume: {peak} dB\n"
+            )
+            return SimpleNamespace(returncode=rc, stdout="", stderr=stderr)
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(preprocess.subprocess, "run", fake_run)
+
+
+def test_parse_volume_db_reads_ffmpeg_volumedetect_output():
+    stderr = "[Parsed_volumedetect_0 @ 0x1] mean_volume: -23.4 dB\n"
+
+    assert preprocess._parse_volume_db(stderr, "mean_volume") == -23.4
+
+
+def test_check_audio_quality_accepts_well_leveled_segment(monkeypatch):
+    _patch_probe_and_volume(monkeypatch, mean="-23.4", peak="-3.2")
+
+    assert preprocess.check_audio_quality("sample.wav")
+
+
+def test_check_audio_quality_rejects_silent_segment(monkeypatch):
+    _patch_probe_and_volume(monkeypatch, mean="-91.0", peak="-90.2")
+
+    assert not preprocess.check_audio_quality("silent.wav")
+
+
+def test_check_audio_quality_rejects_clipped_segment(monkeypatch):
+    _patch_probe_and_volume(monkeypatch, mean="-12.0", peak="0.0")
+
+    assert not preprocess.check_audio_quality("clipped.wav")
+
+
+def test_check_audio_quality_rejects_too_hot_segment(monkeypatch):
+    _patch_probe_and_volume(monkeypatch, mean="-4.8", peak="-1.0")
+
+    assert not preprocess.check_audio_quality("too_hot.wav")
+
+
+def test_check_audio_quality_rejects_missing_volume_metrics(monkeypatch):
+    def fake_run(cmd, **_kwargs):
+        if cmd[0] == "ffprobe":
+            return SimpleNamespace(
+                returncode=0,
+                stdout='{"format": {"duration": "6.0"}}',
+                stderr="",
+            )
+        if cmd[0] == "ffmpeg":
+            return SimpleNamespace(returncode=0, stdout="", stderr="no volume here")
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(preprocess.subprocess, "run", fake_run)
+
+    assert not preprocess.check_audio_quality("unknown.wav")


### PR DESCRIPTION
Reconciles three overlapping preprocess PRs that all rewrote `convert_to_wav`/`check_audio_quality` (so they couldn't merge independently) into one coherent change, then fixes bugs a tri-brain review (Codex + Grok) found in the integration.

## What's integrated
- **#198 (security envelope)** — `-protocol_whitelist file,pipe` on every ffmpeg/ffprobe call, `assert_safe_audio_input()` content-sniff, atomic `mkstemp`+`os.replace` writes, `os.islink` skip, `csv.writer(delimiter="|")` manifest, `_safe_stem()`. Credit: @Vyacheslav-Tomashevskiy
- **#194 (two-pass loudnorm)** — measured loudnorm in `convert_to_wav` + env-var fix + Stage E resume guard. Credit: @Spring0032
- **#197 (RMS/peak quality gate)** — `volumedetect` mean/peak gate in `check_audio_quality` + tests. Credit: @q36zhd46w17o

## Bugs fixed during reconciliation (found by review)
1. **Two-pass loudnorm parse was a no-op** — ffmpeg's `print_format=json` emits a multi-line block; the original parsed line-by-line so `measured_*` never populated and every file silently fell back to single-pass. New `_parse_loudnorm_json()` does a balanced-brace scan and requires `input_i`; pass-2 only runs with all four measured keys.
2. **Extra SSRF hole** — #194's loudnorm pass-1 read the input unguarded; added the protocol whitelist there (only exposed once #194+#198 combine).
3. **`extract_segment` ignored ffmpeg failure** → failed segments could enter the dataset; now propagated.
4. **`_safe_stem` filename collisions** (`a:b`/`a|b`/`a/b` → `a_b`) → distinct inputs overwrote each other; now suffixed with an 8-char hash when sanitization changes the name.
5. **Existing `.wav` bypassed the security sniff on resume** → now sniffed before `split_on_silence`.
6. **`volumedetect` timeout dropped the whole file** → now rejects only that segment.
7. **Stage E resumed on stale data** → now requires the F5 CSV to be newer than its transcribed inputs (+ header/≥100/atomic).

## Tests
`pytest tests/ -q` → **38 passed** (added `test_preprocess_loudnorm.py` covering the JSON parse, resume-sniff, and timeout-rejection paths).

## Known limitations (deferred, non-blocking)
- No real-ffmpeg integration test (no audio fixtures in repo) — validation is unit + spec level; the `target_offset` loudnorm key is mapped per spec, not a live ffmpeg run.
- Manifest uses `csv.writer` quoting — any consumer doing `line.split("|")` (rather than `csv.DictReader`) should be updated.
- The embedded Stage E F5-CSV writer keeps pipe-join (F5-TTS format); sanitize `text` if French transcripts ever contain `|`/newlines.

Closes #198
Closes #197
Closes #194
