### PR TITLE
lexicon: Cajun/Acadian surname respellings (reconciled #192)

### DIFF
--- a/scripts/cajun8h/cajun_lexicon.py
+++ b/scripts/cajun8h/cajun_lexicon.py
@@ -196,6 +196,23 @@ LEXICON = {
     "Sophia Elya":  "Sofia Élia",
     "Elya":         "Élia",
     "Sophia":       "Sofia",
+    # ---- Cajun / Acadian surnames (Louisiana surname rankings + Acadian family lists) ----
+    "Comeaux":      "Como",            # -eaux family-name ending: enforce the Cajun "o" sound
+    "Arceneaux":    "Arsenô",          # common Acadian/Cajun surname; same -eaux -> o pattern
+    "Robichaux":    "Robicho",
+    "Broussard":    "Broussar",        # final consonant softened/silent in French-friendly TTS
+    "Fontenot":     "Fontenô",         # Louisiana surname; final -ot rendered as open "o"
+    "Landry":       "Landri",
+    "LeBlanc":      "Le Blan",         # final c silent in French-style surname pronunciation
+    "Dugas":        "Duga",            # final s silent
+    "Doucet":       "Doucé",           # -cet family-name ending, closer to "doo-say"
+    "Bourgeois":    "Bourjwa",         # French oi -> wa
+    "Richard":      "Richar",          # final d silent
+    "Thériot":      "Tério",
+    "Theriot":      "Tério",
+    "Sonnier":      "Sonyé",
+    "Melançon":     "Mélançon",
+    "Melancon":     "Mélançon",
 }
 
 _lower_index = {k.lower(): v for k, v in LEXICON.items()}

--- a/tests/test_cajun_lexicon.py
+++ b/tests/test_cajun_lexicon.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: MIT
+from scripts.cajun8h.cajun_lexicon import respell, to_js
+
+
+def test_respell_cajun_surnames_uses_acadian_family_name_entries():
+    text = "Comeaux, Arceneaux, Broussard, Fontenot, and Bourgeois arrived."
+
+    assert (
+        respell(text)
+        == "Como, Arsenô, Broussar, Fontenô, and Bourjwa arrived."
+    )
+
+
+def test_respell_cajun_surnames_keeps_ascii_variants_and_capitalization():
+    text = "LeBlanc met Theriot, Sonnier, Doucet, Dugas, and Richard."
+
+    assert (
+        respell(text)
+        == "Le Blan met Tério, Sonyé, Doucé, Duga, and Richar."
+    )
+
+
+def test_cajun_lexicon_js_export_includes_new_entries():
+    js = to_js()
+
+    assert '"Comeaux": "Como"' in js
+    assert '"Bourgeois": "Bourjwa"' in js


### PR DESCRIPTION
Reconciles #192 onto current main (test-file + lexicon overlap resolved, duplicate test renamed). Tests pass (6).

Closes #192