### PR TITLE
lexicon: Cajun culinary respellings (reconciled #196)

### DIFF
--- a/scripts/cajun8h/cajun_lexicon.py
+++ b/scripts/cajun8h/cajun_lexicon.py
@@ -147,6 +147,27 @@ LEXICON = {
     "gru":          "grou",            # groo — grits
     "cabri":        "cabri",           # ka-BREE — goat
     "chaudin":      "chaudin",         # sho-DAN — stuffed pig stomach
+    # ---- Louisiana/Cajun culinary pronunciations (public glossary attested) ----
+    "boudin":       "bou-dan",         # Source: Visit Baton Rouge, Boudin (boo-dan)
+    "boudins":      "bou-dans",        # plural; same attestation as boudin
+    "beignet":      "bèn-yé",          # Source: Visit Baton Rouge, Beignet (bin-yay)
+    "beignets":     "bèn-yés",
+    "courtbouillon":"cou-bouyon",      # Source: Explore Louisiana, Courtbouillon [coo-boo-yon]
+    "court bouillon":"cou-bouyon",
+    "bouillie":     "bou-yee",         # Source: Acadiana Table, Bouillie (BOO yee)
+    "tarte à la bouillie": "tarte à la bou-yee",
+    "tarte a la bouillie": "tarte à la bou-yee",
+    "boulette":     "boulet",          # Source: Acadiana Table, Boulette (BOO let)
+    "boulettes":    "boulets",
+    "roux":         "rou",             # Source: Big Easy Foods, Roux (roo)
+    "grillades":    "gri-yades",       # Source: Big Easy Foods, Grillades (GREE yads)
+    "amandine":     "arman-dine",      # Source: Big Easy Foods, Amandine (ar-man-deen)
+    "au gratin":    "ô gratin",        # Source: Acadiana Table, Au gratin (oh GRAH tan)
+    "cochon de lait":"cou-shon de lait", # Source: Big Easy Foods, Cochon de Lait (coo-shon duh lay)
+    "café au lait": "café ô lait",     # Source: Acadiana Table, Café au Lait (caf AY oh LAY)
+    "cafe au lait": "café ô lait",
+    "rémoulade":    "rémoularde",      # Source: Big Easy Foods, Remoulade (rem-oo-lard)
+    "remoulade":    "rémoularde",
     "quelque chose":"quéque chose",    # kek-SHOWZ — Cajun contraction of "something"
     "quelque":      "quéque",
     "quelqu'un":    "quéqu'un",

--- a/tests/test_cajun_lexicon.py
+++ b/tests/test_cajun_lexicon.py
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: MIT
+from scripts.cajun8h import cajun_lexicon
+
+
+def test_respell_cajun_culinary_terms():
+    text = "Boudin, beignets, courtbouillon, roux, and boulettes."
+
+    assert (
+        cajun_lexicon.respell(text)
+        == "Bou-dan, bèn-yés, cou-bouyon, rou, and boulets."
+    )
+
+
+def test_respell_cajun_culinary_multiword_terms():
+    text = "Serve cochon de lait with tarte a la bouillie and cafe au lait."
+
+    assert (
+        cajun_lexicon.respell(text)
+        == "Serve cou-shon de lait with tarte à la bou-yee and café ô lait."
+    )
+
+
+def test_cajun_lexicon_js_export_includes_culinary_terms():
+    js = cajun_lexicon.to_js()
+
+    assert '"boudin": "bou-dan"' in js
+    assert '"courtbouillon": "cou-bouyon"' in js
+    assert '"remoulade": "rémoularde"' in js


### PR DESCRIPTION
Reconciles #196 onto current main (test-file overlap resolved). Tests pass (9).

Closes #196