### PR TITLE
lexicon: Acadiana town respellings (reconciled #201)

### DIFF
--- a/scripts/cajun8h/cajun_lexicon.py
+++ b/scripts/cajun8h/cajun_lexicon.py
@@ -69,6 +69,21 @@ LEXICON = {
     "Thibodeaux":   "Tibodo",
     "Hebert":       "Ébère",
     "Guidry":       "Guidri",
+    # ---- Acadiana town-name respellings (municipal/place names; ear-tunable) ----
+    "Ville Platte": "Ville Plat",      # Evangeline Parish city; final -e is not voiced
+    "Gueydan":      "Guédan",          # Vermilion Parish town; helps avoid hard English "guy-dan"
+    "Iota":         "Aïota",           # Acadia Parish town; keep the opening eye sound
+    "Duson":        "Duzon",           # Lafayette/Acadia Parish town
+    "Erath":        "Érat",            # Vermilion Parish town
+    "Delcambre":    "Delcambe",        # Iberia/Vermilion Parish town
+    "Mermentau":    "Mermento",        # Acadia Parish village / river name
+    "Meraux":       "Méro",            # St. Bernard Parish community; French -aux ending
+    "Pierre Part":  "Pierre Par",      # Assumption Parish community; final -t is silent
+    "Basile":       "Bazile",          # Evangeline/Acadia Parish town
+    "Rayne":        "Rain",            # Acadia Parish city
+    "Kaplan":       "Caplan",          # Vermilion Parish city
+    "Abbeville":    "Abb-ville",       # Vermilion Parish city; cue the local clipped middle
+    "Church Point": "Church Pointe",   # Acadia Parish town; keep the place-name cadence
     # ---- Cajun / Louisiana French lexicon ----
     "maringouin":   "marin-gouin",
     "maringouins":  "marin-gouins",

--- a/tests/test_cajun_lexicon.py
+++ b/tests/test_cajun_lexicon.py
@@ -1,3 +1,8 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
 from scripts.cajun8h.cajun_lexicon import LEXICON, respell, to_js
 
 
@@ -20,3 +25,28 @@ def test_cajun_lexicon_js_export_includes_new_entries():
     assert LEXICON["crevette"] == "chevrette"
     assert '"pirogue": "pi-ro"' in emitted
     assert '"crevette": "chevrette"' in emitted
+def check_respells_acadiana_town_names():
+    text = "Ville Platte, Gueydan, Duson, Erath, and Pierre Part."
+
+    assert respell(text) == "Ville Plat, Guédan, Duzon, Érat, and Pierre Par."
+
+
+def check_exports_acadiana_town_names_to_js():
+    js = to_js()
+
+    assert '"Ville Platte": "Ville Plat"' in js
+    assert '"Mermentau": "Mermento"' in js
+    assert '"Meraux": "Méro"' in js
+
+
+def test_respells_acadiana_town_names():
+    check_respells_acadiana_town_names()
+
+
+def test_exports_acadiana_town_names_to_js():
+    check_exports_acadiana_town_names_to_js()
+
+
+if __name__ == "__main__":
+    check_respells_acadiana_town_names()
+    check_exports_acadiana_town_names_to_js()


### PR DESCRIPTION
Reconciles #201 onto current main (test-file overlap resolved). Tests pass (11).

Closes #201