### PR TITLE
fix(train_f5): load every manifest schema the pipeline emits (#181)

### DIFF
--- a/scripts/train_f5.py
+++ b/scripts/train_f5.py
@@ -26,18 +26,73 @@ from pathlib import Path
 class VintageVoiceDataset(Dataset):
     """Dataset of preprocessed vintage audio segments with transcriptions"""
 
+    # Accepted column aliases for the audio path. The pipeline emits several
+    # manifest schemas: preprocess.py / fast_manifest.py / auto_pipeline.sh
+    # write ``path|duration|source``, while build_f5_csv.py (the F5 training
+    # CSV) writes ``audio_file|text``. Older code here assumed an ``audio_path``
+    # column that no producer emits, so the loader raised KeyError on the first
+    # row and training never started. Resolve the column flexibly instead.
+    _AUDIO_KEYS = ("audio_path", "path", "audio_file", "wav", "filename")
+    _MIN_DURATION = 2.0
+
     def __init__(self, manifest_path, sample_rate=24000, max_duration=15.0):
         self.sample_rate = sample_rate
         self.max_samples = int(max_duration * sample_rate)
         self.entries = []
 
+        skipped = {"no_audio_col": 0, "missing_file": 0, "no_text": 0, "too_short": 0}
         with open(manifest_path) as f:
             reader = csv.DictReader(f, delimiter="|")
             for row in reader:
-                if os.path.exists(row["audio_path"]) and float(row["duration"]) >= 2.0:
-                    self.entries.append(row)
+                audio_path = next(
+                    (row[k] for k in self._AUDIO_KEYS if row.get(k)), None
+                )
+                if not audio_path:
+                    skipped["no_audio_col"] += 1
+                    continue
+                if not os.path.exists(audio_path):
+                    skipped["missing_file"] += 1
+                    continue
+                text = (row.get("text") or "").strip()
+                if not text:
+                    # An audio-only manifest (path|duration|source) carries no
+                    # transcription; TTS fine-tuning needs the paired text, so
+                    # skip rather than train on an empty target.
+                    skipped["no_text"] += 1
+                    continue
+                duration = self._row_duration(row, audio_path)
+                if duration is not None and duration < self._MIN_DURATION:
+                    skipped["too_short"] += 1
+                    continue
+                self.entries.append({
+                    "audio_path": audio_path,
+                    "text": text,
+                    "duration": float(duration) if duration is not None else 0.0,
+                })
 
         print(f"Dataset: {len(self.entries)} segments")
+        dropped = {k: v for k, v in skipped.items() if v}
+        if dropped:
+            print(f"  (skipped rows: {dropped})")
+
+    @classmethod
+    def _row_duration(cls, row, audio_path):
+        """Duration in seconds from the manifest column, else probed from the
+        audio file. ``f5_train.csv`` (audio_file|text) has no duration column,
+        so fall back to torchaudio metadata instead of KeyError-ing."""
+        raw = row.get("duration")
+        if raw not in (None, ""):
+            try:
+                return float(raw)
+            except (TypeError, ValueError):
+                pass
+        try:
+            info = torchaudio.info(audio_path)
+            if info.sample_rate:
+                return info.num_frames / info.sample_rate
+        except Exception:
+            pass
+        return None
 
     def __len__(self):
         return len(self.entries)

--- a/scripts/train_f5.py
+++ b/scripts/train_f5.py
@@ -26,13 +26,18 @@ from pathlib import Path
 class VintageVoiceDataset(Dataset):
     """Dataset of preprocessed vintage audio segments with transcriptions"""
 
-    # Accepted column aliases for the audio path. The pipeline emits several
-    # manifest schemas: preprocess.py / fast_manifest.py / auto_pipeline.sh
-    # write ``path|duration|source``, while build_f5_csv.py (the F5 training
-    # CSV) writes ``audio_file|text``. Older code here assumed an ``audio_path``
-    # column that no producer emits, so the loader raised KeyError on the first
-    # row and training never started. Resolve the column flexibly instead.
-    _AUDIO_KEYS = ("audio_path", "path", "audio_file", "wav", "filename")
+    # Accepted column aliases for the audio path, in producer-precedence order.
+    # The pipeline emits two manifest schemas: preprocess.py / fast_manifest.py /
+    # auto_pipeline.sh write ``path|duration|source``, while build_f5_csv.py (the
+    # F5 training CSV) writes ``audio_file|text`` — so ``path`` and ``audio_file``
+    # come first. ``audio_path`` is the column older code here wrongly assumed
+    # every producer emits (none does, which is why the loader used to KeyError on
+    # the first row and training never started); it is kept last only as a
+    # defensive fallback so that, should a future writer add it, it cannot silently
+    # shadow the columns producers actually emit today. ``wav``/``filename`` were
+    # dropped — no tool emits them, and speculative aliases only desync this table
+    # from the real pipeline schemas.
+    _AUDIO_KEYS = ("path", "audio_file", "audio_path")
     _MIN_DURATION = 2.0
 
     def __init__(self, manifest_path, sample_rate=24000, max_duration=15.0):
@@ -40,7 +45,13 @@ class VintageVoiceDataset(Dataset):
         self.max_samples = int(max_duration * sample_rate)
         self.entries = []
 
-        skipped = {"no_audio_col": 0, "missing_file": 0, "no_text": 0, "too_short": 0}
+        skipped = {
+            "no_audio_col": 0,
+            "missing_file": 0,
+            "no_text": 0,
+            "no_duration": 0,
+            "too_short": 0,
+        }
         with open(manifest_path) as f:
             reader = csv.DictReader(f, delimiter="|")
             for row in reader:
@@ -61,13 +72,21 @@ class VintageVoiceDataset(Dataset):
                     skipped["no_text"] += 1
                     continue
                 duration = self._row_duration(row, audio_path)
-                if duration is not None and duration < self._MIN_DURATION:
+                if duration is None:
+                    # The manifest carried no usable duration and torchaudio could
+                    # not probe the file (corrupt audio / unsupported format).
+                    # Admitting it as duration=0.0 would slip it past the
+                    # MIN_DURATION guard and corrupt any downstream length-based
+                    # filtering or bucketing, so drop and count it instead.
+                    skipped["no_duration"] += 1
+                    continue
+                if duration < self._MIN_DURATION:
                     skipped["too_short"] += 1
                     continue
                 self.entries.append({
                     "audio_path": audio_path,
                     "text": text,
-                    "duration": float(duration) if duration is not None else 0.0,
+                    "duration": float(duration),
                 })
 
         print(f"Dataset: {len(self.entries)} segments")

--- a/scripts/train_f5.py
+++ b/scripts/train_f5.py
@@ -13,6 +13,7 @@ Based on F5-TTS: https://github.com/SWivid/F5-TTS
 """
 import argparse
 import csv
+import math
 import os
 import random
 
@@ -78,6 +79,12 @@ class VintageVoiceDataset(Dataset):
                     # Admitting it as duration=0.0 would slip it past the
                     # MIN_DURATION guard and corrupt any downstream length-based
                     # filtering or bucketing, so drop and count it instead.
+                    skipped["no_duration"] += 1
+                    continue
+                if not math.isfinite(duration):
+                    # A non-finite duration (NaN/inf) would slip past the
+                    # ``< _MIN_DURATION`` check below, since ``nan < x`` is
+                    # always False, so reject it as an unusable duration.
                     skipped["no_duration"] += 1
                     continue
                 if duration < self._MIN_DURATION:

--- a/tests/test_train_f5_manifest_schema.py
+++ b/tests/test_train_f5_manifest_schema.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: MIT
+"""
+Regression tests for ``VintageVoiceDataset`` manifest parsing (Refs #181).
+
+Bug: the F5 fine-tune dataset loader read a hard-coded ``audio_path`` column
+(and a mandatory ``duration`` column), but no producer in the pipeline emits
+that schema:
+
+- ``preprocess.py`` / ``fast_manifest.py`` / ``auto_pipeline.sh`` write
+  ``path|duration|source``.
+- ``build_f5_csv.py`` (the F5 training CSV that ``auto_pipeline.sh`` builds)
+  writes ``audio_file|text``.
+
+So ``VintageVoiceDataset(manifest)`` raised ``KeyError: 'audio_path'`` on the
+first row and fine-tuning never started. These tests pin the fix: the loader
+resolves the audio column flexibly, requires paired ``text``, and probes the
+clip duration when the manifest has no ``duration`` column.
+"""
+import csv
+
+import pytest
+
+# The trainer pulls in torch/torchaudio; skip cleanly where they are absent
+# (the project's training environment has them — that is where this runs).
+pytest.importorskip("torch")
+pytest.importorskip("torchaudio")
+np = pytest.importorskip("numpy")
+sf = pytest.importorskip("soundfile")
+
+from scripts.train_f5 import VintageVoiceDataset
+
+
+def _wav(path, seconds=3.0, sr=24000):
+    n = int(seconds * sr)
+    sf.write(str(path), np.zeros(n, dtype="float32"), sr)
+
+
+def _write_manifest(path, header, rows):
+    with open(path, "w", newline="") as f:
+        w = csv.writer(f, delimiter="|")
+        w.writerow(header)
+        w.writerows(rows)
+
+
+def test_f5_train_csv_schema_loads(tmp_path):
+    """audio_file|text (build_f5_csv.py output) — no duration column."""
+    wav = tmp_path / "clip1.wav"
+    _wav(wav)
+    manifest = tmp_path / "f5_train.csv"
+    _write_manifest(manifest, ["audio_file", "text"], [[str(wav), "bonjour mes amis"]])
+
+    ds = VintageVoiceDataset(str(manifest))
+
+    assert len(ds) == 1, "audio_file|text manifest must load (was KeyError before)"
+    item = ds[0]
+    assert item["text"] == "bonjour mes amis"
+    assert item["duration"] == pytest.approx(3.0, abs=0.1)  # probed from the wav
+
+
+def test_path_duration_text_schema_loads(tmp_path):
+    """path|duration|text — pipeline manifest extended with transcription."""
+    wav = tmp_path / "clip2.wav"
+    _wav(wav, seconds=4.0)
+    manifest = tmp_path / "manifest.csv"
+    _write_manifest(
+        manifest, ["path", "duration", "text"], [[str(wav), "4.00", "ça c'est bon"]]
+    )
+
+    ds = VintageVoiceDataset(str(manifest))
+
+    assert len(ds) == 1
+    assert ds[0]["duration"] == pytest.approx(4.0, abs=0.01)
+
+
+def test_textless_and_short_rows_are_skipped_not_fatal(tmp_path):
+    """A text-less manifest (path|duration|source) and sub-2s clips are
+    skipped gracefully instead of crashing or being trained on."""
+    good = tmp_path / "good.wav"
+    short = tmp_path / "short.wav"
+    _wav(good, seconds=3.0)
+    _wav(short, seconds=1.0)
+    manifest = tmp_path / "mixed.csv"
+    _write_manifest(
+        manifest,
+        ["audio_file", "duration", "text"],
+        [
+            [str(good), "3.00", "valid line"],
+            [str(short), "1.00", "too short"],          # < 2.0s -> skipped
+            [str(good), "3.00", ""],                    # no text -> skipped
+            [str(tmp_path / "missing.wav"), "3.00", "x"],  # missing file -> skipped
+        ],
+    )
+
+    ds = VintageVoiceDataset(str(manifest))
+
+    assert len(ds) == 1, "only the one valid, transcribed, >=2s row should load"

--- a/tests/test_train_f5_manifest_schema.py
+++ b/tests/test_train_f5_manifest_schema.py
@@ -94,3 +94,30 @@ def test_textless_and_short_rows_are_skipped_not_fatal(tmp_path):
     ds = VintageVoiceDataset(str(manifest))
 
     assert len(ds) == 1, "only the one valid, transcribed, >=2s row should load"
+
+
+def test_unprobeable_duration_is_skipped_not_admitted_as_zero(tmp_path):
+    """A clip whose duration is neither in the manifest nor probeable from the
+    file (corrupt/unsupported audio) must be dropped, not admitted as 0.0 — a
+    0.0 entry would slip past the MIN_DURATION guard and poison downstream
+    length-based bucketing."""
+    good = tmp_path / "good.wav"
+    _wav(good, seconds=3.0)
+    # A path that exists (passes the os.path.exists check) but is not decodable
+    # audio, so torchaudio.info raises and no duration column is present.
+    bogus = tmp_path / "bogus.wav"
+    bogus.write_bytes(b"not really audio")
+    manifest = tmp_path / "noduration.csv"
+    _write_manifest(
+        manifest,
+        ["audio_file", "text"],
+        [
+            [str(good), "valid line"],
+            [str(bogus), "unprobeable clip"],  # duration unknown -> skipped
+        ],
+    )
+
+    ds = VintageVoiceDataset(str(manifest))
+
+    assert len(ds) == 1, "the unprobeable-duration row must be skipped, not kept as 0.0"
+    assert ds[0]["duration"] == pytest.approx(3.0, abs=0.1)


### PR DESCRIPTION
Closes #181 (non-overlapping with the open preprocess.py / cosyvoice claims — this targets `scripts/train_f5.py` only).

### Bug
`VintageVoiceDataset` (the F5 fine-tune data loader) read a hard-coded `audio_path` column and a mandatory `duration` column:

```python
if os.path.exists(row["audio_path"]) and float(row["duration"]) >= 2.0:
```

But **no manifest producer in the repo emits that schema**:

| Producer | Header |
|---|---|
| `preprocess.py`, `fast_manifest.py`, `auto_pipeline.sh` | `path\|duration\|source` |
| `build_f5_csv.py` (the F5 training CSV `auto_pipeline.sh` builds, line 52) | `audio_file\|text` |

There is no `audio_path` column anywhere, so `VintageVoiceDataset(manifest)` raises `KeyError: 'audio_path'` on the **first row** — the 8GB fine-tune never starts, regardless of which manifest you point it at.

### Before / after (no GPU needed — pure manifest parsing)
```
- f5_train.csv (build_f5_csv.py)        OLD: CRASH KeyError('audio_path')   NEW: resolved audio='/seg/clip1.wav'
- manifest.csv (preprocess/auto_pipeline) OLD: CRASH KeyError('audio_path')   NEW: resolved audio='/seg/clip1.wav'
```

### Fix
- Resolve the audio column flexibly (`audio_path` / `path` / `audio_file` / …) so both real schemas load.
- Require paired transcription `text` — skip text-less rows (e.g. the `path|duration|source` manifest carries no transcription) instead of training on an empty target.
- Probe clip duration from the audio file when the manifest has no `duration` column (`f5_train.csv`), instead of `KeyError`-ing.
- Missing-file / text-less / sub-2s rows are skipped with a per-reason tally rather than crashing.

`__getitem__` is unchanged — rows are normalised to `{audio_path, text, duration}` in `__init__`.

### Tests
`tests/test_train_f5_manifest_schema.py` — covers both real schemas plus the skip paths (text-less, missing-file, sub-2s). Uses `pytest.importorskip("torch"/"torchaudio")` so it runs in the training environment and skips cleanly elsewhere. The standalone before/after parsing proof above is reproducible without torch.

---
RTC payout address: `RTCd1554f0f35576faf01d386a6be1c947f560dd0b7` — thanks!
